### PR TITLE
fix: update cross chain logic of native stake

### DIFF
--- a/abi/staking.abi
+++ b/abi/staking.abi
@@ -1,39 +1,15 @@
 [
   {
     "anonymous": false,
-    "inputs": [],
-    "name": "crashResponse",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "delegator",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "oracleRelayerFee",
-        "type": "uint256"
+        "internalType": "uint8",
+        "name": "eventType",
+        "type": "uint8"
       }
     ],
-    "name": "delegateSubmitted",
+    "name": "crashResponse",
     "type": "event"
   },
   {
@@ -64,7 +40,101 @@
         "type": "uint8"
       }
     ],
-    "name": "failedDelegate",
+    "name": "delegateFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "delegateSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "delegateSuccess",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint8",
+        "name": "eventType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "errCode",
+        "type": "uint256"
+      }
+    ],
+    "name": "failedSynPackage",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "key",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "value",
+        "type": "bytes"
+      }
+    ],
+    "name": "paramChange",
     "type": "event"
   },
   {
@@ -101,70 +171,7 @@
         "type": "uint8"
       }
     ],
-    "name": "failedRedelegate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "errCode",
-        "type": "uint256"
-      }
-    ],
-    "name": "failedSynPackage",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "delegator",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "amount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint8",
-        "name": "errCode",
-        "type": "uint8"
-      }
-    ],
-    "name": "failedUndelegate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "string",
-        "name": "key",
-        "type": "string"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "value",
-        "type": "bytes"
-      }
-    ],
-    "name": "paramChange",
+    "name": "redelegateFailed",
     "type": "event"
   },
   {
@@ -197,11 +204,42 @@
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "oracleRelayerFee",
+        "name": "relayerFee",
         "type": "uint256"
       }
     ],
     "name": "redelegateSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "valSrc",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "valDst",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "redelegateSuccess",
     "type": "event"
   },
   {
@@ -265,12 +303,68 @@
       },
       {
         "indexed": false,
+        "internalType": "uint8",
+        "name": "errCode",
+        "type": "uint8"
+      }
+    ],
+    "name": "undelegateFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
         "internalType": "uint256",
-        "name": "oracleRelayerFee",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "relayerFee",
         "type": "uint256"
       }
     ],
     "name": "undelegateSubmitted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "undelegateSuccess",
     "type": "event"
   },
   {
@@ -302,6 +396,12 @@
         "type": "address"
       },
       {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
         "indexed": false,
         "internalType": "uint256",
         "name": "amount",
@@ -326,12 +426,38 @@
   },
   {
     "inputs": [],
+    "name": "CODE_FAILED",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "CODE_OK",
     "outputs": [
       {
         "internalType": "uint32",
         "name": "",
         "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "CODE_SUCCESS",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
       }
     ],
     "stateMutability": "view",
@@ -366,19 +492,6 @@
   {
     "inputs": [],
     "name": "ERROR_FAIL_DECODE",
-    "outputs": [
-      {
-        "internalType": "uint32",
-        "name": "",
-        "type": "uint32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "ERROR_UNKNOWN_PACKAGE_TYPE",
     "outputs": [
       {
         "internalType": "uint32",
@@ -508,7 +621,7 @@
   },
   {
     "inputs": [],
-    "name": "INIT_MIN_DELEGATION_CHANGE",
+    "name": "INIT_MIN_DELEGATION",
     "outputs": [
       {
         "internalType": "uint256",
@@ -521,7 +634,7 @@
   },
   {
     "inputs": [],
-    "name": "INIT_ORACLE_RELAYER_FEE",
+    "name": "INIT_RELAYER_FEE",
     "outputs": [
       {
         "internalType": "uint256",
@@ -540,6 +653,19 @@
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LOCK_TIME",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -729,7 +855,7 @@
   },
   {
     "inputs": [],
-    "name": "minDelegationChange",
+    "name": "minDelegation",
     "outputs": [
       {
         "internalType": "uint256",
@@ -742,7 +868,7 @@
   },
   {
     "inputs": [],
-    "name": "oracleRelayerFee",
+    "name": "relayerFee",
     "outputs": [
       {
         "internalType": "uint256",
@@ -808,7 +934,7 @@
       },
       {
         "internalType": "bytes",
-        "name": "",
+        "name": "msgBytes",
         "type": "bytes"
       }
     ],
@@ -891,7 +1017,7 @@
   },
   {
     "inputs": [],
-    "name": "claimUndeldegated",
+    "name": "claimUndelegated",
     "outputs": [
       {
         "internalType": "uint256",
@@ -934,7 +1060,55 @@
         "type": "address"
       }
     ],
+    "name": "getTotalDelegated",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      }
+    ],
     "name": "getDistributedReward",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "valSrc",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "valDst",
+        "type": "address"
+      }
+    ],
+    "name": "getPendingRedelegateTime",
     "outputs": [
       {
         "internalType": "uint256",
@@ -977,7 +1151,7 @@
         "type": "address"
       }
     ],
-    "name": "getPendingUndelegated",
+    "name": "getPendingUndelegateTime",
     "outputs": [
       {
         "internalType": "uint256",
@@ -990,7 +1164,7 @@
   },
   {
     "inputs": [],
-    "name": "getOracleRelayerFee",
+    "name": "getRelayerFee",
     "outputs": [
       {
         "internalType": "uint256",
@@ -1003,12 +1177,25 @@
   },
   {
     "inputs": [],
-    "name": "getMinDelegationChange",
+    "name": "getMinDelegation",
     "outputs": [
       {
         "internalType": "uint256",
         "name": "",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRequestInFly",
+    "outputs": [
+      {
+        "internalType": "uint256[3]",
+        "name": "",
+        "type": "uint256[3]"
       }
     ],
     "stateMutability": "view",

--- a/abi/staking.abi
+++ b/abi/staking.abi
@@ -621,6 +621,19 @@
   },
   {
     "inputs": [],
+    "name": "INIT_BSC_RELAYER_FEE",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "INIT_MIN_DELEGATION",
     "outputs": [
       {
@@ -835,6 +848,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bSCRelayerFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -1189,7 +1215,13 @@
     "type": "function"
   },
   {
-    "inputs": [],
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "delegator",
+        "type": "address"
+      }
+    ],
     "name": "getRequestInFly",
     "outputs": [
       {

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -37,10 +37,12 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   uint256 public constant TEN_DECIMALS = 1e10;
   uint256 public constant LOCK_TIME = 8 days; // 8*24*3600 second
 
-  uint256 public constant INIT_RELAYER_FEE = 12 * 1e15;
+  uint256 public constant INIT_RELAYER_FEE = 16 * 1e15;
+  uint256 public constant INIT_BSC_RELAYER_FEE = 1 * 1e16;
   uint256 public constant INIT_MIN_DELEGATION = 100 * 1e18;
 
   uint256 public relayerFee;
+  uint256 public bSCRelayerFee;
   uint256 public minDelegation;
 
   mapping(address => uint256) delegated; // delegator => totalAmount
@@ -74,6 +76,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   modifier initParams() {
     if (!alreadyInit) {
       relayerFee = INIT_RELAYER_FEE;
+      bSCRelayerFee = INIT_BSC_RELAYER_FEE;
       minDelegation = INIT_MIN_DELEGATION;
       alreadyInit = true;
     }
@@ -193,8 +196,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = (msg.value).sub(amount);
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -206,7 +208,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     delegateInFly[msg.sender] += 1;
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(amount+ oracleRelayerFee);
+    payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, _relayerFee);
@@ -215,7 +217,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(msg.value >= relayerFee, "not enough relay fee");
     if (amount < minDelegation) {
-      require(amount > relayerFee>>1, "not enough funds");
+      require(amount > bSCRelayerFee, "not enough funds");
       require(amount == delegatedOfValidator[msg.sender][validator], "invalid amount");
     }
     require(delegatedOfValidator[msg.sender][validator] >= amount, "invalid amount");
@@ -223,8 +225,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -251,8 +252,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](4);
     elements[0] = msg.sender.encodeAddress();
@@ -282,7 +282,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
   function claimUndelegated() override external noReentrant returns(uint256 amount) {
     amount = undelegated[msg.sender];
-    require(undelegated[msg.sender] > 0, "no undelegated funds");
+    require(amount > 0, "no undelegated funds");
 
     undelegated[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
@@ -367,7 +367,13 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       require(value.length == 32, "length of relayerFee mismatch");
       uint256 newRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newRelayerFee < minDelegation, "the relayerFee must be less than minDelegation");
+      require(newRelayerFee > bSCRelayerFee, "the relayerFee must be more than BSCRelayerFee");
       relayerFee = newRelayerFee;
+    } else if (Memory.compareStrings(key, "bSCRelayerFee")) {
+      require(value.length == 32, "length of bSCRelayerFee mismatch");
+      uint256 newBSCRelayerFee = BytesToTypes.bytesToUint256(32, value);
+      require(newBSCRelayerFee < relayerFee, "the BSCRelayerFee must be less than relayerFee");
+      bSCRelayerFee = newBSCRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");
       uint256 newMinDelegation = BytesToTypes.bytesToUint256(32, value);

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -1,17 +1,19 @@
 pragma solidity 0.6.4;
 
 import "./System.sol";
-import "./lib/Memory.sol";
-import "./lib/BytesToTypes.sol";
 import "./interface/IApplication.sol";
 import "./interface/ICrossChain.sol";
 import "./interface/IParamSubscriber.sol";
+import "./interface/IStaking.sol";
 import "./interface/ITokenHub.sol";
+import "./lib/BytesToTypes.sol";
+import "./lib/BytesLib.sol";
 import "./lib/CmnPkg.sol";
-import "./lib/SafeMath.sol";
+import "./lib/Memory.sol";
 import "./lib/RLPEncode.sol";
 import "./lib/RLPDecode.sol";
-import "./interface/IStaking.sol";
+import "./lib/SafeMath.sol";
+
 
 contract Staking is IStaking, System, IParamSubscriber, IApplication {
   using SafeMath for uint256;
@@ -29,8 +31,9 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   uint32 public constant ERROR_WITHDRAW_BNB = 101;
 
   uint256 public constant TEN_DECIMALS = 1e10;
+  uint256 public constant LOCK_TIME = 691200; // 8*24*3600
 
-  uint256 public constant INIT_ORACLE_RELAYER_FEE = 6e15;
+  uint256 public constant INIT_ORACLE_RELAYER_FEE = 12 * 1e15;
   uint256 public constant INIT_MIN_DELEGATION = 100 * 1e18;
 
   uint256 public oracleRelayerFee;
@@ -42,14 +45,20 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   mapping(address => mapping(address => uint256)) pendingUndelegateTime; // delegator => validator => minTime
   mapping(address => uint256) undelegated; // delegator => totalUndelegated
   mapping(address => mapping(address => mapping(address => uint256))) pendingRedelegateTime; // delegator => srcValidator => dstValidator => minTime
+  mapping(uint256 => bytes32) packageQueue; // index => package's hash
+  mapping(address => uint256) delegateInFly; // delegator => delegate request in fly;
+  mapping(address => uint256) undelegateInFly; // delegator => undelegate request in fly;
+  mapping(address => uint256) redelegateInFly; // delegator => redelegate request in fly;
 
-  bool internal locked;
+  uint256 internal leftIndex;
+  uint256 internal rightIndex;
+  uint8 internal locked;
 
   modifier noReentrant() {
-    require(!locked, "No re-entrancy");
-    locked = true;
+    require(locked != 2, "No re-entrancy");
+    locked = 2;
     _;
-    locked = false;
+    locked = 1;
   }
 
   modifier tenDecimalPrecision(uint256 amount) {
@@ -74,9 +83,12 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   event rewardClaimed(address indexed delegator, uint256 amount);
   event undelegatedReceived(address indexed delegator, address indexed validator, uint256 amount);
   event undelegatedClaimed(address indexed delegator, uint256 amount);
-  event failedDelegate(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
-  event failedUndelegate(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
-  event failedRedelegate(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount, uint8 errCode);
+  event delegateSuccess(address indexed delegator, address indexed validator, uint256 amount);
+  event undelegateSuccess(address indexed delegator, address indexed validator, uint256 amount);
+  event redelegateSuccess(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount);
+  event delegateFailed(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
+  event undelegateFailed(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
+  event redelegateFailed(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount, uint8 errCode);
   event paramChange(string key, bytes value);
   event failedSynPackage(uint8 indexed eventType, uint256 errCode);
   event crashResponse(uint8 indexed eventType);
@@ -94,7 +106,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     } else if (eventType == EVENT_DISTRIBUTE_UNDELEGATED) {
       (resCode, ackPackage) = _handleDistributeUndelegatedSynPackage(iter);
     } else {
-      require(false, "unknown event type");
+      revert("unknown event type");
     }
 
     if (resCode != CODE_OK) {
@@ -105,36 +117,70 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
   function handleAckPackage(uint8, bytes calldata msgBytes) external onlyCrossChainContract initParams override {
     RLPDecode.Iterator memory iter = msgBytes.toRLPItem().iterator();
-    uint8 eventType = uint8(iter.next().toUint());
-    if (eventType == EVENT_DELEGATE) {
-      _handleDelegateAckPackage(iter);
-    } else if (eventType == EVENT_UNDELEGATE) {
-      _handleUndelegateAckPackage(iter);
-    } else if (eventType == EVENT_REDELEGATE) {
-      _handleRedelegateAckPackage(iter);
-    } else {
-      require(false, "unknown event type");
+
+    uint8 status;
+    uint8 errCode;
+    bytes memory packBytes;
+    bool success;
+    uint256 idx;
+    while (iter.hasNext()) {
+      if (idx == 0) {
+        status = uint8(iter.next().toUint());
+      } else if (idx == 1) {
+        errCode = uint8(iter.next().toUint());
+      } else if (idx == 2) {
+        packBytes = iter.next().toBytes();
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
     }
-    return;
+
+    require(_checkPackHash(packBytes), "wrong pack hash");
+    iter = packBytes.toRLPItem().iterator();
+    uint8 eventType = uint8(iter.next().toUint());
+    RLPDecode.Iterator memory paramIter;
+    if (iter.hasNext()) {
+      paramIter = iter.next().toBytes().toRLPItem().iterator();
+    } else {
+      revert("empty ack package");
+    }
+    if (eventType == EVENT_DELEGATE) {
+      _handleDelegateAckPackage(paramIter, status, errCode);
+    } else if (eventType == EVENT_UNDELEGATE) {
+      _handleUndelegateAckPackage(paramIter, status, errCode);
+    } else if (eventType == EVENT_REDELEGATE) {
+      _handleRedelegateAckPackage(paramIter, status, errCode);
+    } else {
+      revert("unknown event type");
+    }
   }
 
   function handleFailAckPackage(uint8, bytes calldata msgBytes) external onlyCrossChainContract initParams override {
+    require(_checkPackHash(msgBytes), "wrong pack hash");
     RLPDecode.Iterator memory iter = msgBytes.toRLPItem().iterator();
     uint8 eventType = uint8(iter.next().toUint());
-    if (eventType == EVENT_DELEGATE) {
-      _handleDelegateFailAckPackage(iter);
-    } else if (eventType == EVENT_UNDELEGATE) {
-      _handleUndelegateFailAckPackage(iter);
-    } else if (eventType == EVENT_REDELEGATE) {
-      _handleRedelegateFailAckPackage(iter);
+    RLPDecode.Iterator memory paramIter;
+    if (iter.hasNext()) {
+      paramIter = iter.next().toBytes().toRLPItem().iterator();
     } else {
-      require(false, "unknown event type");
+      revert("empty fail ack package");
+    }
+    if (eventType == EVENT_DELEGATE) {
+      _handleDelegateFailAckPackage(paramIter);
+    } else if (eventType == EVENT_UNDELEGATE) {
+      _handleUndelegateFailAckPackage(paramIter);
+    } else if (eventType == EVENT_REDELEGATE) {
+      _handleRedelegateFailAckPackage(paramIter);
+    } else {
+      revert("unknown event type");
     }
     return;
   }
 
   /***************************** External functions *****************************/
-  function delegate(address validator, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function delegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(amount >= minDelegation, "invalid delegate amount");
     require(msg.value >= amount.add(oracleRelayerFee), "not enough msg value");
     require(payable(msg.sender).send(0), "invalid delegator"); // the msg sender must be payable
@@ -146,24 +192,25 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[0] = msg.sender.encodeAddress();
     elements[1] = validator.encodeAddress();
     elements[2] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_DELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(msg.value);
+    bytes memory msgBytes = _RLPEncode(EVENT_DELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    delegateInFly[msg.sender] += 1;
 
-    delegated[msg.sender] = delegated[msg.sender].add(amount);
-    delegatedOfValidator[msg.sender][validator] = delegatedOfValidator[msg.sender][validator].add(amount);
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
   }
 
-  function undelegate(address validator, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(msg.value >= oracleRelayerFee, "not enough relay fee");
     if (amount < minDelegation) {
-      require(amount >= oracleRelayerFee, "not enough funds");
+      require(amount > oracleRelayerFee, "not enough funds");
       require(amount == delegatedOfValidator[msg.sender][validator], "invalid amount");
     }
+    require(delegatedOfValidator[msg.sender][validator] >= amount, "invalid amount");
     require(block.timestamp >= pendingUndelegateTime[msg.sender][validator], "pending undelegation exist");
-    delegatedOfValidator[msg.sender][validator] = delegatedOfValidator[msg.sender][validator].sub(amount, "not enough funds");
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _oracleRelayerFee = msg.value;
@@ -172,24 +219,23 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[0] = msg.sender.encodeAddress();
     elements[1] = validator.encodeAddress();
     elements[2] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_UNDELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    bytes memory msgBytes = _RLPEncode(EVENT_UNDELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    undelegateInFly[msg.sender] += 1;
 
-    delegated[msg.sender] = delegated[msg.sender].sub(amount);
-    pendingUndelegateTime[msg.sender][validator] = block.timestamp.add(691200); // 8*24*3600
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit undelegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
   }
 
-  function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external noReentrant payable tenDecimalPrecision(amount) initParams {
     require(validatorSrc != validatorDst, "invalid redelegation");
     require(msg.value >= oracleRelayerFee, "not enough relay fee");
-    require(amount >= minDelegation, "invalid amount");
+    require(amount >= minDelegation && delegatedOfValidator[msg.sender][validatorSrc] >= amount, "invalid amount");
     require(block.timestamp >= pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] &&
       block.timestamp >= pendingRedelegateTime[msg.sender][validatorDst][validatorSrc], "pending redelegation exist");
-    delegatedOfValidator[msg.sender][validatorSrc] = delegatedOfValidator[msg.sender][validatorSrc].sub(amount, "not enough funds");
-    delegatedOfValidator[msg.sender][validatorDst] = delegatedOfValidator[msg.sender][validatorDst].add(amount);
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _oracleRelayerFee = msg.value;
@@ -199,29 +245,30 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[1] = validatorSrc.encodeAddress();
     elements[2] = validatorDst.encodeAddress();
     elements[3] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_REDELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    bytes memory msgBytes = _RLPEncode(EVENT_REDELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    redelegateInFly[msg.sender] += 1;
 
-    pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] = block.timestamp.add(691200); // 8*24*3600
-    pendingRedelegateTime[msg.sender][validatorDst][validatorSrc] = block.timestamp.add(691200); // 8*24*3600
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _oracleRelayerFee);
   }
 
   function claimReward() override external noReentrant returns(uint256 amount) {
-    require(distributedReward[msg.sender] > 0, "no pending reward");
-
     amount = distributedReward[msg.sender];
+    require(amount > 0, "no pending reward");
+
     distributedReward[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
     emit rewardClaimed(msg.sender, amount);
   }
 
-  function claimUndeldegated() override external noReentrant returns(uint256 amount) {
+  function claimUndelegated() override external noReentrant returns(uint256 amount) {
+    amount = undelegated[msg.sender];
     require(undelegated[msg.sender] > 0, "no undelegated funds");
 
-    amount = undelegated[msg.sender];
     undelegated[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
     emit undelegatedClaimed(msg.sender, amount);
@@ -259,6 +306,14 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     return minDelegation;
   }
 
+  function getRequestInFly() override external view returns(uint256[3] memory) {
+    uint256[3] memory request;
+    request[0] = delegateInFly[msg.sender];
+    request[1] = undelegateInFly[msg.sender];
+    request[2] = redelegateInFly[msg.sender];
+    return request;
+  }
+
   /***************************** Internal functions *****************************/
   function _RLPEncode(uint8 eventType, bytes memory msgBytes) internal pure returns(bytes memory output) {
     bytes[] memory elements = new bytes[](2);
@@ -283,227 +338,220 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     if (Memory.compareStrings(key, "oracleRelayerFee")) {
       require(value.length == 32, "length of oracleRelayerFee mismatch");
       uint256 newOracleRelayerFee = BytesToTypes.bytesToUint256(32, value);
-      require(newOracleRelayerFee >0, "the oracleRelayerFee must be greater than 0");
+      require(newOracleRelayerFee < minDelegation, "the oracleRelayerFee must be less than minDelegation");
       oracleRelayerFee = newOracleRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");
       uint256 newMinDelegation = BytesToTypes.bytesToUint256(32, value);
-      require(newMinDelegation > 0, "the minDelegation must be greater than 0");
+      require(newMinDelegation > oracleRelayerFee, "the minDelegation must be greater than oracleRelayerFee");
       minDelegation = newMinDelegation;
     } else {
-      require(false, "unknown param");
+      revert("unknown param");
     }
     emit paramChange(key, value);
   }
 
   /************************* Handle cross-chain package *************************/
-  function _handleDelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address validator;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 3) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw from tokenhub failed");
-
-    delegated[delegator] = delegated[delegator].sub(amount);
-    undelegated[delegator] = undelegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
-
-    emit failedDelegate(delegator, validator, amount, errCode);
-  }
-
-  function _handleDelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleDelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address validator;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
+        validator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw from tokenhub failed");
+    delegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegated[delegator] = delegated[delegator].add(amount);
+      delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
 
-    delegated[delegator] = delegated[delegator].sub(amount);
+      emit delegateSuccess(delegator, validator, amount);
+      payable(TOKEN_HUB_ADDR).transfer(amount);
+    } else if (status == 0) {
+      undelegated[delegator] = undelegated[delegator].add(amount);
+      emit delegateFailed(delegator, validator, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleDelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address validator;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        validator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    uint256 amount = bcAmount.mul(TEN_DECIMALS);
+    delegateInFly[delegator] -= 1;
     undelegated[delegator] = undelegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
 
     emit crashResponse(EVENT_DELEGATE);
   }
 
-  function _handleUndelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address validator;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 3) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    delegated[delegator] = delegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
-    pendingUndelegateTime[delegator][validator] = 0;
-
-    emit failedUndelegate(delegator, validator, amount, errCode);
-  }
-
-  function _handleUndelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleUndelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address validator;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
+        validator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    delegated[delegator] = delegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
+    undelegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegated[delegator] = delegated[delegator].sub(amount);
+      delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
+      pendingUndelegateTime[delegator][validator] = block.timestamp.add(LOCK_TIME);
+      require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw BNB failed");
+
+      emit undelegateSuccess(delegator, validator, amount);
+    } else if (status == 0) {
+      pendingUndelegateTime[delegator][validator] = 0;
+      emit undelegateFailed(delegator, validator, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleUndelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address validator;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        validator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    undelegateInFly[delegator] -= 1;
     pendingUndelegateTime[delegator][validator] = 0;
 
     emit crashResponse(EVENT_UNDELEGATE);
   }
 
-  function _handleRedelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address valSrc;
-    address valDst;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        valSrc = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        valDst = address(uint160(iter.next().toAddress()));
-      } else if (idx == 3) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 4) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].add(amount);
-    delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].sub(amount);
-    pendingRedelegateTime[delegator][valSrc][valDst] = 0;
-    pendingRedelegateTime[delegator][valDst][valSrc] = 0;
-
-    emit failedRedelegate(delegator, valSrc, valDst, amount, errCode);
-  }
-
-  function _handleRedelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleRedelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address valSrc;
     address valDst;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        valSrc = address(uint160(iter.next().toAddress()));
+        valSrc = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        valDst = address(uint160(iter.next().toAddress()));
+        valDst = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 3) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].add(amount);
-    delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].sub(amount);
+    redelegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].sub(amount);
+      delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].add(amount);
+      pendingRedelegateTime[delegator][valSrc][valDst] = block.timestamp.add(LOCK_TIME);
+      pendingRedelegateTime[delegator][valDst][valSrc] = block.timestamp.add(LOCK_TIME);
+
+      emit redelegateSuccess(delegator, valSrc, valDst, amount);
+    } else if (status == 0) {
+      pendingRedelegateTime[delegator][valSrc][valDst] = 0;
+      pendingRedelegateTime[delegator][valDst][valSrc] = 0;
+      emit redelegateFailed(delegator, valSrc, valDst, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleRedelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address valSrc;
+    address valDst;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        valSrc = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        valDst = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 3) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    redelegateInFly[delegator] -= 1;
     pendingRedelegateTime[delegator][valSrc][valDst] = 0;
     pendingRedelegateTime[delegator][valDst][valSrc] = 0;
 
@@ -511,20 +559,20 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   }
 
   function _handleDistributeRewardSynPackage(RLPDecode.Iterator memory iter) internal returns(uint32, bytes memory) {
-    bool success = false;
-    uint256 idx = 0;
-    uint256 amount;
+    bool success;
+    uint256 idx;
     address recipient;
+    uint256 amount;
     while (iter.hasNext()) {
       if (idx == 0) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 1) {
         recipient = address(uint160(iter.next().toAddress()));
+      } else if (idx == 1) {
+        amount = uint256(iter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
     if (!success) {
       return _encodeRefundPackage(EVENT_DISTRIBUTE_REWARD, amount, recipient, ERROR_FAIL_DECODE);
@@ -542,23 +590,23 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   }
 
   function _handleDistributeUndelegatedSynPackage(RLPDecode.Iterator memory iter) internal returns(uint32, bytes memory) {
-    bool success = false;
-    uint256 idx = 0;
-    uint256 amount;
+    bool success;
+    uint256 idx;
     address recipient;
     address validator;
+    uint256 amount;
     while (iter.hasNext()) {
       if (idx == 0) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 1) {
         recipient = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
+      } else if (idx == 1) {
         validator = address(uint160(iter.next().toAddress()));
+      } else if (idx == 2) {
+        amount = uint256(iter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
     if (!success) {
       return _encodeRefundPackage(EVENT_DISTRIBUTE_UNDELEGATED, amount, recipient, ERROR_FAIL_DECODE);
@@ -574,5 +622,18 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     emit undelegatedReceived(recipient, validator, amount);
     return (CODE_OK, new bytes(0));
+  }
+
+  function _checkPackHash(bytes memory packBytes) internal returns(bool){
+    bytes32 revHash = keccak256(packBytes);
+    bytes32 expHash = packageQueue[leftIndex];
+    for (uint i;i<32;++i) {
+      if (revHash[i] != expHash[i]) {
+        return false;
+      }
+    }
+    delete packageQueue[leftIndex];
+    ++leftIndex;
+    return true;
   }
 }

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -196,7 +196,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = (msg.value).sub(amount);
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -208,7 +208,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     delegateInFly[msg.sender] += 1;
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
+    payable(TOKEN_HUB_ADDR).transfer(amount.add(oracleRelayerFee));
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
@@ -225,7 +225,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -235,6 +235,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     packageQueue[rightIndex] = keccak256(msgBytes);
     ++rightIndex;
     undelegateInFly[msg.sender] += 1;
+
+    pendingUndelegateTime[msg.sender][validator] = block.timestamp.add(LOCK_TIME);
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
@@ -252,7 +254,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](4);
     elements[0] = msg.sender.encodeAddress();
@@ -264,6 +266,9 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     ++rightIndex;
     redelegateInFly[msg.sender] += 1;
 
+    pendingRedelegateTime[msg.sender][validatorDst][validatorSrc] = block.timestamp.add(LOCK_TIME);
+    pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] = block.timestamp.add(LOCK_TIME);
+    
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
@@ -321,11 +326,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     return minDelegation;
   }
 
-  function getRequestInFly() override external view returns(uint256[3] memory) {
+  function getRequestInFly(address delegator) override external view returns(uint256[3] memory) {
     uint256[3] memory request;
-    request[0] = delegateInFly[msg.sender];
-    request[1] = undelegateInFly[msg.sender];
-    request[2] = redelegateInFly[msg.sender];
+    request[0] = delegateInFly[delegator];
+    request[1] = undelegateInFly[delegator];
+    request[2] = redelegateInFly[delegator];
     return request;
   }
 
@@ -351,10 +356,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   function _checkPackHash(bytes memory packBytes) internal returns(bool){
     bytes32 revHash = keccak256(packBytes);
     bytes32 expHash = packageQueue[leftIndex];
-    for (uint i;i<32;++i) {
-      if (revHash[i] != expHash[i]) {
-        return false;
-      }
+    if (revHash != expHash) {
+      return false;
     }
     delete packageQueue[leftIndex];
     ++leftIndex;
@@ -368,11 +371,13 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       uint256 newRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newRelayerFee < minDelegation, "the relayerFee must be less than minDelegation");
       require(newRelayerFee > bSCRelayerFee, "the relayerFee must be more than BSCRelayerFee");
+      require(newRelayerFee%TEN_DECIMALS==0, "the relayerFee mod ten decimals must be zero");
       relayerFee = newRelayerFee;
     } else if (Memory.compareStrings(key, "bSCRelayerFee")) {
       require(value.length == 32, "length of bSCRelayerFee mismatch");
       uint256 newBSCRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newBSCRelayerFee < relayerFee, "the BSCRelayerFee must be less than relayerFee");
+      require(newBSCRelayerFee%TEN_DECIMALS==0, "the BSCRelayerFee mod ten decimals must be zero");
       bSCRelayerFee = newBSCRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -211,7 +211,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit delegateSubmitted(msg.sender, validator, amount, _relayerFee);
+    emit delegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
   }
 
   function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
@@ -240,7 +240,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit undelegateSubmitted(msg.sender, validator, amount, _relayerFee);
+    emit undelegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
   }
 
   function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external noReentrant payable tenDecimalPrecision(amount) initParams {
@@ -268,7 +268,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _relayerFee);
+    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, oracleRelayerFee);
   }
 
   function claimReward() override external noReentrant returns(uint256 amount) {

--- a/contracts/Staking.template
+++ b/contracts/Staking.template
@@ -100,14 +100,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   event paramChange(string key, bytes value);
   event failedSynPackage(uint8 indexed eventType, uint256 errCode);
   event crashResponse(uint8 indexed eventType);
-{% if mock %}
-  /*********************** init **************************/
-  function init() external onlyNotInit {
-    oracleRelayerFee = INIT_ORACLE_RELAYER_FEE;
-    minDelegation = INIT_MIN_DELEGATION;
-    alreadyInit = true;
-  }
-{% endif %}
+
   receive() external payable {}
 
   /************************* Implement cross chain app *************************/
@@ -218,7 +211,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit delegateSubmitted(msg.sender, validator, amount, _relayerFee);
+    emit delegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
   }
 
   function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
@@ -247,7 +240,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit undelegateSubmitted(msg.sender, validator, amount, _relayerFee);
+    emit undelegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
   }
 
   function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external noReentrant payable tenDecimalPrecision(amount) initParams {
@@ -275,7 +268,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _relayerFee);
+    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, oracleRelayerFee);
   }
 
   function claimReward() override external noReentrant returns(uint256 amount) {

--- a/contracts/Staking.template
+++ b/contracts/Staking.template
@@ -1,17 +1,19 @@
 pragma solidity 0.6.4;
 
 import "./System.sol";
-import "./lib/Memory.sol";
-import "./lib/BytesToTypes.sol";
 import "./interface/IApplication.sol";
 import "./interface/ICrossChain.sol";
 import "./interface/IParamSubscriber.sol";
+import "./interface/IStaking.sol";
 import "./interface/ITokenHub.sol";
+import "./lib/BytesToTypes.sol";
+import "./lib/BytesLib.sol";
 import "./lib/CmnPkg.sol";
-import "./lib/SafeMath.sol";
+import "./lib/Memory.sol";
 import "./lib/RLPEncode.sol";
 import "./lib/RLPDecode.sol";
-import "./interface/IStaking.sol";
+import "./lib/SafeMath.sol";
+
 
 contract Staking is IStaking, System, IParamSubscriber, IApplication {
   using SafeMath for uint256;
@@ -29,8 +31,9 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   uint32 public constant ERROR_WITHDRAW_BNB = 101;
 
   uint256 public constant TEN_DECIMALS = 1e10;
+  uint256 public constant LOCK_TIME = 691200; // 8*24*3600
 
-  uint256 public constant INIT_ORACLE_RELAYER_FEE = 6e15;
+  uint256 public constant INIT_ORACLE_RELAYER_FEE = 12 * 1e15;
   uint256 public constant INIT_MIN_DELEGATION = 100 * 1e18;
 
   uint256 public oracleRelayerFee;
@@ -42,14 +45,20 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   mapping(address => mapping(address => uint256)) pendingUndelegateTime; // delegator => validator => minTime
   mapping(address => uint256) undelegated; // delegator => totalUndelegated
   mapping(address => mapping(address => mapping(address => uint256))) pendingRedelegateTime; // delegator => srcValidator => dstValidator => minTime
+  mapping(uint256 => bytes32) packageQueue; // index => package's hash
+  mapping(address => uint256) delegateInFly; // delegator => delegate request in fly;
+  mapping(address => uint256) undelegateInFly; // delegator => undelegate request in fly;
+  mapping(address => uint256) redelegateInFly; // delegator => redelegate request in fly;
 
-  bool internal locked;
+  uint256 internal leftIndex;
+  uint256 internal rightIndex;
+  uint8 internal locked;
 
   modifier noReentrant() {
-    require(!locked, "No re-entrancy");
-    locked = true;
+    require(locked != 2, "No re-entrancy");
+    locked = 2;
     _;
-    locked = false;
+    locked = 1;
   }
 
   modifier tenDecimalPrecision(uint256 amount) {
@@ -74,9 +83,12 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   event rewardClaimed(address indexed delegator, uint256 amount);
   event undelegatedReceived(address indexed delegator, address indexed validator, uint256 amount);
   event undelegatedClaimed(address indexed delegator, uint256 amount);
-  event failedDelegate(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
-  event failedUndelegate(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
-  event failedRedelegate(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount, uint8 errCode);
+  event delegateSuccess(address indexed delegator, address indexed validator, uint256 amount);
+  event undelegateSuccess(address indexed delegator, address indexed validator, uint256 amount);
+  event redelegateSuccess(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount);
+  event delegateFailed(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
+  event undelegateFailed(address indexed delegator, address indexed validator, uint256 amount, uint8 errCode);
+  event redelegateFailed(address indexed delegator, address indexed valSrc, address indexed valDst, uint256 amount, uint8 errCode);
   event paramChange(string key, bytes value);
   event failedSynPackage(uint8 indexed eventType, uint256 errCode);
   event crashResponse(uint8 indexed eventType);
@@ -101,7 +113,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     } else if (eventType == EVENT_DISTRIBUTE_UNDELEGATED) {
       (resCode, ackPackage) = _handleDistributeUndelegatedSynPackage(iter);
     } else {
-      require(false, "unknown event type");
+      revert("unknown event type");
     }
 
     if (resCode != CODE_OK) {
@@ -112,36 +124,70 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
   function handleAckPackage(uint8, bytes calldata msgBytes) external onlyCrossChainContract initParams override {
     RLPDecode.Iterator memory iter = msgBytes.toRLPItem().iterator();
-    uint8 eventType = uint8(iter.next().toUint());
-    if (eventType == EVENT_DELEGATE) {
-      _handleDelegateAckPackage(iter);
-    } else if (eventType == EVENT_UNDELEGATE) {
-      _handleUndelegateAckPackage(iter);
-    } else if (eventType == EVENT_REDELEGATE) {
-      _handleRedelegateAckPackage(iter);
-    } else {
-      require(false, "unknown event type");
+
+    uint8 status;
+    uint8 errCode;
+    bytes memory packBytes;
+    bool success;
+    uint256 idx;
+    while (iter.hasNext()) {
+      if (idx == 0) {
+        status = uint8(iter.next().toUint());
+      } else if (idx == 1) {
+        errCode = uint8(iter.next().toUint());
+      } else if (idx == 2) {
+        packBytes = iter.next().toBytes();
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
     }
-    return;
+
+    require(_checkPackHash(packBytes), "wrong pack hash");
+    iter = packBytes.toRLPItem().iterator();
+    uint8 eventType = uint8(iter.next().toUint());
+    RLPDecode.Iterator memory paramIter;
+    if (iter.hasNext()) {
+      paramIter = iter.next().toBytes().toRLPItem().iterator();
+    } else {
+      revert("empty ack package");
+    }
+    if (eventType == EVENT_DELEGATE) {
+      _handleDelegateAckPackage(paramIter, status, errCode);
+    } else if (eventType == EVENT_UNDELEGATE) {
+      _handleUndelegateAckPackage(paramIter, status, errCode);
+    } else if (eventType == EVENT_REDELEGATE) {
+      _handleRedelegateAckPackage(paramIter, status, errCode);
+    } else {
+      revert("unknown event type");
+    }
   }
 
   function handleFailAckPackage(uint8, bytes calldata msgBytes) external onlyCrossChainContract initParams override {
+    require(_checkPackHash(msgBytes), "wrong pack hash");
     RLPDecode.Iterator memory iter = msgBytes.toRLPItem().iterator();
     uint8 eventType = uint8(iter.next().toUint());
-    if (eventType == EVENT_DELEGATE) {
-      _handleDelegateFailAckPackage(iter);
-    } else if (eventType == EVENT_UNDELEGATE) {
-      _handleUndelegateFailAckPackage(iter);
-    } else if (eventType == EVENT_REDELEGATE) {
-      _handleRedelegateFailAckPackage(iter);
+    RLPDecode.Iterator memory paramIter;
+    if (iter.hasNext()) {
+      paramIter = iter.next().toBytes().toRLPItem().iterator();
     } else {
-      require(false, "unknown event type");
+      revert("empty fail ack package");
+    }
+    if (eventType == EVENT_DELEGATE) {
+      _handleDelegateFailAckPackage(paramIter);
+    } else if (eventType == EVENT_UNDELEGATE) {
+      _handleUndelegateFailAckPackage(paramIter);
+    } else if (eventType == EVENT_REDELEGATE) {
+      _handleRedelegateFailAckPackage(paramIter);
+    } else {
+      revert("unknown event type");
     }
     return;
   }
 
   /***************************** External functions *****************************/
-  function delegate(address validator, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function delegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(amount >= minDelegation, "invalid delegate amount");
     require(msg.value >= amount.add(oracleRelayerFee), "not enough msg value");
     require(payable(msg.sender).send(0), "invalid delegator"); // the msg sender must be payable
@@ -153,24 +199,25 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[0] = msg.sender.encodeAddress();
     elements[1] = validator.encodeAddress();
     elements[2] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_DELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(msg.value);
+    bytes memory msgBytes = _RLPEncode(EVENT_DELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    delegateInFly[msg.sender] += 1;
 
-    delegated[msg.sender] = delegated[msg.sender].add(amount);
-    delegatedOfValidator[msg.sender][validator] = delegatedOfValidator[msg.sender][validator].add(amount);
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
   }
 
-  function undelegate(address validator, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(msg.value >= oracleRelayerFee, "not enough relay fee");
     if (amount < minDelegation) {
-      require(amount >= oracleRelayerFee, "not enough funds");
+      require(amount > oracleRelayerFee, "not enough funds");
       require(amount == delegatedOfValidator[msg.sender][validator], "invalid amount");
     }
+    require(delegatedOfValidator[msg.sender][validator] >= amount, "invalid amount");
     require(block.timestamp >= pendingUndelegateTime[msg.sender][validator], "pending undelegation exist");
-    delegatedOfValidator[msg.sender][validator] = delegatedOfValidator[msg.sender][validator].sub(amount, "not enough funds");
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _oracleRelayerFee = msg.value;
@@ -179,24 +226,23 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[0] = msg.sender.encodeAddress();
     elements[1] = validator.encodeAddress();
     elements[2] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_UNDELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    bytes memory msgBytes = _RLPEncode(EVENT_UNDELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    undelegateInFly[msg.sender] += 1;
 
-    delegated[msg.sender] = delegated[msg.sender].sub(amount);
-    pendingUndelegateTime[msg.sender][validator] = block.timestamp.add(691200); // 8*24*3600
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit undelegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
   }
 
-  function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external payable tenDecimalPrecision(amount) initParams {
+  function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external noReentrant payable tenDecimalPrecision(amount) initParams {
     require(validatorSrc != validatorDst, "invalid redelegation");
     require(msg.value >= oracleRelayerFee, "not enough relay fee");
-    require(amount >= minDelegation, "invalid amount");
+    require(amount >= minDelegation && delegatedOfValidator[msg.sender][validatorSrc] >= amount, "invalid amount");
     require(block.timestamp >= pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] &&
       block.timestamp >= pendingRedelegateTime[msg.sender][validatorDst][validatorSrc], "pending redelegation exist");
-    delegatedOfValidator[msg.sender][validatorSrc] = delegatedOfValidator[msg.sender][validatorSrc].sub(amount, "not enough funds");
-    delegatedOfValidator[msg.sender][validatorDst] = delegatedOfValidator[msg.sender][validatorDst].add(amount);
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _oracleRelayerFee = msg.value;
@@ -206,29 +252,30 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     elements[1] = validatorSrc.encodeAddress();
     elements[2] = validatorDst.encodeAddress();
     elements[3] = convertedAmount.encodeUint();
-    bytes memory msgBytes = elements.encodeList();
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, _RLPEncode(EVENT_REDELEGATE, msgBytes), _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    bytes memory msgBytes = _RLPEncode(EVENT_REDELEGATE, elements.encodeList());
+    packageQueue[rightIndex] = keccak256(msgBytes);
+    ++rightIndex;
+    redelegateInFly[msg.sender] += 1;
 
-    pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] = block.timestamp.add(691200); // 8*24*3600
-    pendingRedelegateTime[msg.sender][validatorDst][validatorSrc] = block.timestamp.add(691200); // 8*24*3600
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
 
     emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _oracleRelayerFee);
   }
 
   function claimReward() override external noReentrant returns(uint256 amount) {
-    require(distributedReward[msg.sender] > 0, "no pending reward");
-
     amount = distributedReward[msg.sender];
+    require(amount > 0, "no pending reward");
+
     distributedReward[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
     emit rewardClaimed(msg.sender, amount);
   }
 
-  function claimUndeldegated() override external noReentrant returns(uint256 amount) {
+  function claimUndelegated() override external noReentrant returns(uint256 amount) {
+    amount = undelegated[msg.sender];
     require(undelegated[msg.sender] > 0, "no undelegated funds");
 
-    amount = undelegated[msg.sender];
     undelegated[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
     emit undelegatedClaimed(msg.sender, amount);
@@ -266,6 +313,14 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     return minDelegation;
   }
 
+  function getRequestInFly() override external view returns(uint256[3] memory) {
+    uint256[3] memory request;
+    request[0] = delegateInFly[msg.sender];
+    request[1] = undelegateInFly[msg.sender];
+    request[2] = redelegateInFly[msg.sender];
+    return request;
+  }
+
   /***************************** Internal functions *****************************/
   function _RLPEncode(uint8 eventType, bytes memory msgBytes) internal pure returns(bytes memory output) {
     bytes[] memory elements = new bytes[](2);
@@ -290,227 +345,220 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     if (Memory.compareStrings(key, "oracleRelayerFee")) {
       require(value.length == 32, "length of oracleRelayerFee mismatch");
       uint256 newOracleRelayerFee = BytesToTypes.bytesToUint256(32, value);
-      require(newOracleRelayerFee >0, "the oracleRelayerFee must be greater than 0");
+      require(newOracleRelayerFee < minDelegation, "the oracleRelayerFee must be less than minDelegation");
       oracleRelayerFee = newOracleRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");
       uint256 newMinDelegation = BytesToTypes.bytesToUint256(32, value);
-      require(newMinDelegation > 0, "the minDelegation must be greater than 0");
+      require(newMinDelegation > oracleRelayerFee, "the minDelegation must be greater than oracleRelayerFee");
       minDelegation = newMinDelegation;
     } else {
-      require(false, "unknown param");
+      revert("unknown param");
     }
     emit paramChange(key, value);
   }
 
   /************************* Handle cross-chain package *************************/
-  function _handleDelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address validator;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 3) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw from tokenhub failed");
-
-    delegated[delegator] = delegated[delegator].sub(amount);
-    undelegated[delegator] = undelegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
-
-    emit failedDelegate(delegator, validator, amount, errCode);
-  }
-
-  function _handleDelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleDelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address validator;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
+        validator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw from tokenhub failed");
+    delegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegated[delegator] = delegated[delegator].add(amount);
+      delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
 
-    delegated[delegator] = delegated[delegator].sub(amount);
+      emit delegateSuccess(delegator, validator, amount);
+      payable(TOKEN_HUB_ADDR).transfer(amount);
+    } else if (status == 0) {
+      undelegated[delegator] = undelegated[delegator].add(amount);
+      emit delegateFailed(delegator, validator, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleDelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address validator;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        validator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    uint256 amount = bcAmount.mul(TEN_DECIMALS);
+    delegateInFly[delegator] -= 1;
     undelegated[delegator] = undelegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
 
     emit crashResponse(EVENT_DELEGATE);
   }
 
-  function _handleUndelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address validator;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 3) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    delegated[delegator] = delegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
-    pendingUndelegateTime[delegator][validator] = 0;
-
-    emit failedUndelegate(delegator, validator, amount, errCode);
-  }
-
-  function _handleUndelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleUndelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address validator;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        validator = address(uint160(iter.next().toAddress()));
+        validator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    delegated[delegator] = delegated[delegator].add(amount);
-    delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
+    undelegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegated[delegator] = delegated[delegator].sub(amount);
+      delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
+      pendingUndelegateTime[delegator][validator] = block.timestamp.add(LOCK_TIME);
+      require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw BNB failed");
+
+      emit undelegateSuccess(delegator, validator, amount);
+    } else if (status == 0) {
+      pendingUndelegateTime[delegator][validator] = 0;
+      emit undelegateFailed(delegator, validator, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleUndelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address validator;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        validator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    undelegateInFly[delegator] -= 1;
     pendingUndelegateTime[delegator][validator] = 0;
 
     emit crashResponse(EVENT_UNDELEGATE);
   }
 
-  function _handleRedelegateAckPackage(RLPDecode.Iterator memory iter) internal {
-    bool success = false;
-    uint256 idx = 0;
-    address delegator;
-    address valSrc;
-    address valDst;
-    uint256 amount;
-    uint8 errCode;
-    while (iter.hasNext()) {
-      if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
-      } else if (idx == 1) {
-        valSrc = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
-        valDst = address(uint160(iter.next().toAddress()));
-      } else if (idx == 3) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 4) {
-        errCode = uint8(iter.next().toUint());
-        success = true;
-      } else {
-        break;
-      }
-      idx++;
-    }
-    require(success, "rlp decode package failed");
-
-    delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].add(amount);
-    delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].sub(amount);
-    pendingRedelegateTime[delegator][valSrc][valDst] = 0;
-    pendingRedelegateTime[delegator][valDst][valSrc] = 0;
-
-    emit failedRedelegate(delegator, valSrc, valDst, amount, errCode);
-  }
-
-  function _handleRedelegateFailAckPackage(RLPDecode.Iterator memory paramBytes) internal {
-    RLPDecode.Iterator memory iter;
-    if (paramBytes.hasNext()) {
-      iter = paramBytes.next().toBytes().toRLPItem().iterator();
-    } else {
-      require(false, "empty fail ack package");
-    }
-
-    bool success = false;
-    uint256 idx = 0;
+  function _handleRedelegateAckPackage(RLPDecode.Iterator memory paramIter, uint8 status, uint8 errCode) internal {
+    bool success;
+    uint256 idx;
     address delegator;
     address valSrc;
     address valDst;
     uint256 bcAmount;
-    while (iter.hasNext()) {
+    while (paramIter.hasNext()) {
       if (idx == 0) {
-        delegator = address(uint160(iter.next().toAddress()));
+        delegator = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 1) {
-        valSrc = address(uint160(iter.next().toAddress()));
+        valSrc = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 2) {
-        valDst = address(uint160(iter.next().toAddress()));
+        valDst = address(uint160(paramIter.next().toAddress()));
       } else if (idx == 3) {
-        bcAmount = uint256(iter.next().toUint());
+        bcAmount = uint256(paramIter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
-    require(success, "rlp decode package failed");
+    require(success, "rlp decode failed");
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
-    delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].add(amount);
-    delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].sub(amount);
+    redelegateInFly[delegator] -= 1;
+    if (status == 1) {
+      require(errCode == 0, "wrong status");
+      delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].sub(amount);
+      delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].add(amount);
+      pendingRedelegateTime[delegator][valSrc][valDst] = block.timestamp.add(LOCK_TIME);
+      pendingRedelegateTime[delegator][valDst][valSrc] = block.timestamp.add(LOCK_TIME);
+
+      emit redelegateSuccess(delegator, valSrc, valDst, amount);
+    } else if (status == 0) {
+      pendingRedelegateTime[delegator][valSrc][valDst] = 0;
+      pendingRedelegateTime[delegator][valDst][valSrc] = 0;
+      emit redelegateFailed(delegator, valSrc, valDst, amount, errCode);
+    } else {
+      revert("wrong status");
+    }
+  }
+
+  function _handleRedelegateFailAckPackage(RLPDecode.Iterator memory paramIter) internal {
+    bool success;
+    uint256 idx;
+    address delegator;
+    address valSrc;
+    address valDst;
+    uint256 bcAmount;
+    while (paramIter.hasNext()) {
+      if (idx == 0) {
+        delegator = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 1) {
+        valSrc = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 2) {
+        valDst = address(uint160(paramIter.next().toAddress()));
+      } else if (idx == 3) {
+        bcAmount = uint256(paramIter.next().toUint());
+        success = true;
+      } else {
+        break;
+      }
+      ++idx;
+    }
+    require(success, "rlp decode failed");
+
+    redelegateInFly[delegator] -= 1;
     pendingRedelegateTime[delegator][valSrc][valDst] = 0;
     pendingRedelegateTime[delegator][valDst][valSrc] = 0;
 
@@ -518,20 +566,20 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   }
 
   function _handleDistributeRewardSynPackage(RLPDecode.Iterator memory iter) internal returns(uint32, bytes memory) {
-    bool success = false;
-    uint256 idx = 0;
-    uint256 amount;
+    bool success;
+    uint256 idx;
     address recipient;
+    uint256 amount;
     while (iter.hasNext()) {
       if (idx == 0) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 1) {
         recipient = address(uint160(iter.next().toAddress()));
+      } else if (idx == 1) {
+        amount = uint256(iter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
     if (!success) {
       return _encodeRefundPackage(EVENT_DISTRIBUTE_REWARD, amount, recipient, ERROR_FAIL_DECODE);
@@ -549,23 +597,23 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   }
 
   function _handleDistributeUndelegatedSynPackage(RLPDecode.Iterator memory iter) internal returns(uint32, bytes memory) {
-    bool success = false;
-    uint256 idx = 0;
-    uint256 amount;
+    bool success;
+    uint256 idx;
     address recipient;
     address validator;
+    uint256 amount;
     while (iter.hasNext()) {
       if (idx == 0) {
-        amount = uint256(iter.next().toUint());
-      } else if (idx == 1) {
         recipient = address(uint160(iter.next().toAddress()));
-      } else if (idx == 2) {
+      } else if (idx == 1) {
         validator = address(uint160(iter.next().toAddress()));
+      } else if (idx == 2) {
+        amount = uint256(iter.next().toUint());
         success = true;
       } else {
         break;
       }
-      idx++;
+      ++idx;
     }
     if (!success) {
       return _encodeRefundPackage(EVENT_DISTRIBUTE_UNDELEGATED, amount, recipient, ERROR_FAIL_DECODE);
@@ -581,5 +629,18 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     emit undelegatedReceived(recipient, validator, amount);
     return (CODE_OK, new bytes(0));
+  }
+
+  function _checkPackHash(bytes memory packBytes) internal returns(bool){
+    bytes32 revHash = keccak256(packBytes);
+    bytes32 expHash = packageQueue[leftIndex];
+    for (uint i;i<32;++i) {
+      if (revHash[i] != expHash[i]) {
+        return false;
+      }
+    }
+    delete packageQueue[leftIndex];
+    ++leftIndex;
+    return true;
   }
 }

--- a/contracts/Staking.template
+++ b/contracts/Staking.template
@@ -196,7 +196,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = (msg.value).sub(amount);
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -208,7 +208,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     delegateInFly[msg.sender] += 1;
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
+    payable(TOKEN_HUB_ADDR).transfer(amount.add(oracleRelayerFee));
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, oracleRelayerFee);
@@ -225,7 +225,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -235,6 +235,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     packageQueue[rightIndex] = keccak256(msgBytes);
     ++rightIndex;
     undelegateInFly[msg.sender] += 1;
+
+    pendingUndelegateTime[msg.sender][validator] = block.timestamp.add(LOCK_TIME);
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
@@ -252,7 +254,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee.sub(bSCRelayerFee);
 
     bytes[] memory elements = new bytes[](4);
     elements[0] = msg.sender.encodeAddress();
@@ -263,6 +265,9 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     packageQueue[rightIndex] = keccak256(msgBytes);
     ++rightIndex;
     redelegateInFly[msg.sender] += 1;
+
+    pendingRedelegateTime[msg.sender][validatorDst][validatorSrc] = block.timestamp.add(LOCK_TIME);
+    pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] = block.timestamp.add(LOCK_TIME);
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
     payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
@@ -321,11 +326,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     return minDelegation;
   }
 
-  function getRequestInFly() override external view returns(uint256[3] memory) {
+  function getRequestInFly(address delegator) override external view returns(uint256[3] memory) {
     uint256[3] memory request;
-    request[0] = delegateInFly[msg.sender];
-    request[1] = undelegateInFly[msg.sender];
-    request[2] = redelegateInFly[msg.sender];
+    request[0] = delegateInFly[delegator];
+    request[1] = undelegateInFly[delegator];
+    request[2] = redelegateInFly[delegator];
     return request;
   }
 
@@ -351,10 +356,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   function _checkPackHash(bytes memory packBytes) internal returns(bool){
     bytes32 revHash = keccak256(packBytes);
     bytes32 expHash = packageQueue[leftIndex];
-    for (uint i;i<32;++i) {
-      if (revHash[i] != expHash[i]) {
-        return false;
-      }
+    if (revHash != expHash) {
+      return false;
     }
     delete packageQueue[leftIndex];
     ++leftIndex;
@@ -368,11 +371,13 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       uint256 newRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newRelayerFee < minDelegation, "the relayerFee must be less than minDelegation");
       require(newRelayerFee > bSCRelayerFee, "the relayerFee must be more than BSCRelayerFee");
+      require(newRelayerFee%TEN_DECIMALS==0, "the relayerFee mod ten decimals must be zero");
       relayerFee = newRelayerFee;
     } else if (Memory.compareStrings(key, "bSCRelayerFee")) {
       require(value.length == 32, "length of bSCRelayerFee mismatch");
       uint256 newBSCRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newBSCRelayerFee < relayerFee, "the BSCRelayerFee must be less than relayerFee");
+      require(newBSCRelayerFee%TEN_DECIMALS==0, "the BSCRelayerFee mod ten decimals must be zero");
       bSCRelayerFee = newBSCRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");

--- a/contracts/Staking.template
+++ b/contracts/Staking.template
@@ -37,10 +37,12 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   uint256 public constant TEN_DECIMALS = 1e10;
   uint256 public constant LOCK_TIME = 8 days; // 8*24*3600 second
 
-  uint256 public constant INIT_RELAYER_FEE = 12 * 1e15;
+  uint256 public constant INIT_RELAYER_FEE = 16 * 1e15;
+  uint256 public constant INIT_BSC_RELAYER_FEE = 1 * 1e16;
   uint256 public constant INIT_MIN_DELEGATION = 100 * 1e18;
 
   uint256 public relayerFee;
+  uint256 public bSCRelayerFee;
   uint256 public minDelegation;
 
   mapping(address => uint256) delegated; // delegator => totalAmount
@@ -74,6 +76,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   modifier initParams() {
     if (!alreadyInit) {
       relayerFee = INIT_RELAYER_FEE;
+      bSCRelayerFee = INIT_BSC_RELAYER_FEE;
       minDelegation = INIT_MIN_DELEGATION;
       alreadyInit = true;
     }
@@ -200,8 +203,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = (msg.value).sub(amount);
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -213,7 +215,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     delegateInFly[msg.sender] += 1;
 
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(amount+ oracleRelayerFee);
+    payable(TOKEN_HUB_ADDR).transfer(amount+oracleRelayerFee);
     payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
     emit delegateSubmitted(msg.sender, validator, amount, _relayerFee);
@@ -222,7 +224,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(msg.value >= relayerFee, "not enough relay fee");
     if (amount < minDelegation) {
-      require(amount > relayerFee>>1, "not enough funds");
+      require(amount > bSCRelayerFee, "not enough funds");
       require(amount == delegatedOfValidator[msg.sender][validator], "invalid amount");
     }
     require(delegatedOfValidator[msg.sender][validator] >= amount, "invalid amount");
@@ -230,8 +232,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -258,8 +259,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
     uint256 _relayerFee = msg.value;
-    uint256 oracleRelayerFee = _relayerFee>>1;
-    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
+    uint256 oracleRelayerFee = _relayerFee-bSCRelayerFee;
 
     bytes[] memory elements = new bytes[](4);
     elements[0] = msg.sender.encodeAddress();
@@ -289,7 +289,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
   function claimUndelegated() override external noReentrant returns(uint256 amount) {
     amount = undelegated[msg.sender];
-    require(undelegated[msg.sender] > 0, "no undelegated funds");
+    require(amount > 0, "no undelegated funds");
 
     undelegated[msg.sender] = 0;
     payable(msg.sender).transfer(amount);
@@ -374,7 +374,13 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       require(value.length == 32, "length of relayerFee mismatch");
       uint256 newRelayerFee = BytesToTypes.bytesToUint256(32, value);
       require(newRelayerFee < minDelegation, "the relayerFee must be less than minDelegation");
+      require(newRelayerFee > bSCRelayerFee, "the relayerFee must be more than BSCRelayerFee");
       relayerFee = newRelayerFee;
+    } else if (Memory.compareStrings(key, "bSCRelayerFee")) {
+      require(value.length == 32, "length of bSCRelayerFee mismatch");
+      uint256 newBSCRelayerFee = BytesToTypes.bytesToUint256(32, value);
+      require(newBSCRelayerFee < relayerFee, "the BSCRelayerFee must be less than relayerFee");
+      bSCRelayerFee = newBSCRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");
       uint256 newMinDelegation = BytesToTypes.bytesToUint256(32, value);

--- a/contracts/Staking.template
+++ b/contracts/Staking.template
@@ -27,16 +27,20 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   uint8 public constant EVENT_DISTRIBUTE_REWARD = 0x04;
   uint8 public constant EVENT_DISTRIBUTE_UNDELEGATED = 0x05;
 
+  // ack package status code
+  uint8 public constant CODE_FAILED = 0;
+  uint8 public constant CODE_SUCCESS = 1;
+
   // Error code
   uint32 public constant ERROR_WITHDRAW_BNB = 101;
 
   uint256 public constant TEN_DECIMALS = 1e10;
-  uint256 public constant LOCK_TIME = 691200; // 8*24*3600
+  uint256 public constant LOCK_TIME = 8 days; // 8*24*3600 second
 
-  uint256 public constant INIT_ORACLE_RELAYER_FEE = 12 * 1e15;
+  uint256 public constant INIT_RELAYER_FEE = 12 * 1e15;
   uint256 public constant INIT_MIN_DELEGATION = 100 * 1e18;
 
-  uint256 public oracleRelayerFee;
+  uint256 public relayerFee;
   uint256 public minDelegation;
 
   mapping(address => uint256) delegated; // delegator => totalAmount
@@ -45,10 +49,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   mapping(address => mapping(address => uint256)) pendingUndelegateTime; // delegator => validator => minTime
   mapping(address => uint256) undelegated; // delegator => totalUndelegated
   mapping(address => mapping(address => mapping(address => uint256))) pendingRedelegateTime; // delegator => srcValidator => dstValidator => minTime
+
   mapping(uint256 => bytes32) packageQueue; // index => package's hash
-  mapping(address => uint256) delegateInFly; // delegator => delegate request in fly;
-  mapping(address => uint256) undelegateInFly; // delegator => undelegate request in fly;
-  mapping(address => uint256) redelegateInFly; // delegator => redelegate request in fly;
+  mapping(address => uint256) delegateInFly; // delegator => delegate request in fly
+  mapping(address => uint256) undelegateInFly; // delegator => undelegate request in fly
+  mapping(address => uint256) redelegateInFly; // delegator => redelegate request in fly
 
   uint256 internal leftIndex;
   uint256 internal rightIndex;
@@ -68,7 +73,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
   modifier initParams() {
     if (!alreadyInit) {
-      oracleRelayerFee = INIT_ORACLE_RELAYER_FEE;
+      relayerFee = INIT_RELAYER_FEE;
       minDelegation = INIT_MIN_DELEGATION;
       alreadyInit = true;
     }
@@ -76,9 +81,9 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   }
 
   /*********************************** Events **********************************/
-  event delegateSubmitted(address indexed delegator, address indexed validator, uint256 amount, uint256 oracleRelayerFee);
-  event undelegateSubmitted(address indexed delegator, address indexed validator, uint256 amount, uint256 oracleRelayerFee);
-  event redelegateSubmitted(address indexed delegator, address indexed validatorSrc, address indexed validatorDst, uint256 amount, uint256 oracleRelayerFee);
+  event delegateSubmitted(address indexed delegator, address indexed validator, uint256 amount, uint256 relayerFee);
+  event undelegateSubmitted(address indexed delegator, address indexed validator, uint256 amount, uint256 relayerFee);
+  event redelegateSubmitted(address indexed delegator, address indexed validatorSrc, address indexed validatorDst, uint256 amount, uint256 relayerFee);
   event rewardReceived(address indexed delegator, uint256 amount);
   event rewardClaimed(address indexed delegator, uint256 amount);
   event undelegatedReceived(address indexed delegator, address indexed validator, uint256 amount);
@@ -143,6 +148,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       }
       ++idx;
     }
+    require(success, "rlp decode failed");
 
     require(_checkPackHash(packBytes), "wrong pack hash");
     iter = packBytes.toRLPItem().iterator();
@@ -189,11 +195,13 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
   /***************************** External functions *****************************/
   function delegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
     require(amount >= minDelegation, "invalid delegate amount");
-    require(msg.value >= amount.add(oracleRelayerFee), "not enough msg value");
+    require(msg.value >= amount.add(relayerFee), "not enough msg value");
     require(payable(msg.sender).send(0), "invalid delegator"); // the msg sender must be payable
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
-    uint256 _oracleRelayerFee = (msg.value).sub(amount);
+    uint256 _relayerFee = (msg.value).sub(amount);
+    uint256 oracleRelayerFee = _relayerFee>>1;
+    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -204,23 +212,26 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     ++rightIndex;
     delegateInFly[msg.sender] += 1;
 
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(amount+ oracleRelayerFee);
+    payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit delegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
+    emit delegateSubmitted(msg.sender, validator, amount, _relayerFee);
   }
 
   function undelegate(address validator, uint256 amount) override external payable noReentrant tenDecimalPrecision(amount) initParams {
-    require(msg.value >= oracleRelayerFee, "not enough relay fee");
+    require(msg.value >= relayerFee, "not enough relay fee");
     if (amount < minDelegation) {
-      require(amount > oracleRelayerFee, "not enough funds");
+      require(amount > relayerFee>>1, "not enough funds");
       require(amount == delegatedOfValidator[msg.sender][validator], "invalid amount");
     }
     require(delegatedOfValidator[msg.sender][validator] >= amount, "invalid amount");
     require(block.timestamp >= pendingUndelegateTime[msg.sender][validator], "pending undelegation exist");
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
-    uint256 _oracleRelayerFee = msg.value;
+    uint256 _relayerFee = msg.value;
+    uint256 oracleRelayerFee = _relayerFee>>1;
+    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
 
     bytes[] memory elements = new bytes[](3);
     elements[0] = msg.sender.encodeAddress();
@@ -231,21 +242,24 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     ++rightIndex;
     undelegateInFly[msg.sender] += 1;
 
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
+    payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit undelegateSubmitted(msg.sender, validator, amount, _oracleRelayerFee);
+    emit undelegateSubmitted(msg.sender, validator, amount, _relayerFee);
   }
 
   function redelegate(address validatorSrc, address validatorDst, uint256 amount) override external noReentrant payable tenDecimalPrecision(amount) initParams {
     require(validatorSrc != validatorDst, "invalid redelegation");
-    require(msg.value >= oracleRelayerFee, "not enough relay fee");
+    require(msg.value >= relayerFee, "not enough relay fee");
     require(amount >= minDelegation && delegatedOfValidator[msg.sender][validatorSrc] >= amount, "invalid amount");
     require(block.timestamp >= pendingRedelegateTime[msg.sender][validatorSrc][validatorDst] &&
       block.timestamp >= pendingRedelegateTime[msg.sender][validatorDst][validatorSrc], "pending redelegation exist");
 
     uint256 convertedAmount = amount.div(TEN_DECIMALS);// native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
-    uint256 _oracleRelayerFee = msg.value;
+    uint256 _relayerFee = msg.value;
+    uint256 oracleRelayerFee = _relayerFee>>1;
+    uint256 bSCRelayerFee = _relayerFee-oracleRelayerFee;
 
     bytes[] memory elements = new bytes[](4);
     elements[0] = msg.sender.encodeAddress();
@@ -257,10 +271,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     ++rightIndex;
     redelegateInFly[msg.sender] += 1;
 
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, _oracleRelayerFee.div(TEN_DECIMALS));
-    payable(TOKEN_HUB_ADDR).transfer(_oracleRelayerFee);
+    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(CROSS_STAKE_CHANNELID, msgBytes, oracleRelayerFee.div(TEN_DECIMALS));
+    payable(TOKEN_HUB_ADDR).transfer(oracleRelayerFee);
+    payable(SYSTEM_REWARD_ADDR).transfer(bSCRelayerFee);
 
-    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _oracleRelayerFee);
+    emit redelegateSubmitted(msg.sender, validatorSrc, validatorDst, amount, _relayerFee);
   }
 
   function claimReward() override external noReentrant returns(uint256 amount) {
@@ -305,8 +320,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     return pendingUndelegateTime[delegator][validator];
   }
 
-  function getOracleRelayerFee() override external view returns(uint256) {
-    return oracleRelayerFee;
+  function getRelayerFee() override external view returns(uint256) {
+    return relayerFee;
   }
 
   function getMinDelegation() override external view returns(uint256) {
@@ -329,28 +344,41 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     output = elements.encodeList();
   }
 
-  function _encodeRefundPackage(uint8 eventType, uint256 amount, address recipient, uint32 errorCode) internal pure returns(uint32, bytes memory) {
+  function _encodeRefundPackage(uint8 eventType, address recipient, uint256 amount, uint32 errorCode) internal pure returns(uint32, bytes memory) {
     amount = amount.div(TEN_DECIMALS);
     bytes[] memory elements = new bytes[](4);
     elements[0] = eventType.encodeUint();
-    elements[1] = amount.encodeUint();
-    elements[2] = recipient.encodeAddress();
+    elements[1] = recipient.encodeAddress();
+    elements[2] = amount.encodeUint();
     elements[3] = errorCode.encodeUint();
     bytes memory packageBytes = elements.encodeList();
     return (errorCode, packageBytes);
   }
 
+  function _checkPackHash(bytes memory packBytes) internal returns(bool){
+    bytes32 revHash = keccak256(packBytes);
+    bytes32 expHash = packageQueue[leftIndex];
+    for (uint i;i<32;++i) {
+      if (revHash[i] != expHash[i]) {
+        return false;
+      }
+    }
+    delete packageQueue[leftIndex];
+    ++leftIndex;
+    return true;
+  }
+
   /******************************** Param update ********************************/
   function updateParam(string calldata key, bytes calldata value) override external onlyInit onlyGov {
-    if (Memory.compareStrings(key, "oracleRelayerFee")) {
-      require(value.length == 32, "length of oracleRelayerFee mismatch");
-      uint256 newOracleRelayerFee = BytesToTypes.bytesToUint256(32, value);
-      require(newOracleRelayerFee < minDelegation, "the oracleRelayerFee must be less than minDelegation");
-      oracleRelayerFee = newOracleRelayerFee;
+    if (Memory.compareStrings(key, "relayerFee")) {
+      require(value.length == 32, "length of relayerFee mismatch");
+      uint256 newRelayerFee = BytesToTypes.bytesToUint256(32, value);
+      require(newRelayerFee < minDelegation, "the relayerFee must be less than minDelegation");
+      relayerFee = newRelayerFee;
     } else if (Memory.compareStrings(key, "minDelegation")) {
       require(value.length == 32, "length of minDelegation mismatch");
       uint256 newMinDelegation = BytesToTypes.bytesToUint256(32, value);
-      require(newMinDelegation > oracleRelayerFee, "the minDelegation must be greater than oracleRelayerFee");
+      require(newMinDelegation > relayerFee, "the minDelegation must be greater than relayerFee");
       minDelegation = newMinDelegation;
     } else {
       revert("unknown param");
@@ -382,15 +410,16 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
     delegateInFly[delegator] -= 1;
-    if (status == 1) {
+    if (status == CODE_SUCCESS) {
       require(errCode == 0, "wrong status");
       delegated[delegator] = delegated[delegator].add(amount);
       delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].add(amount);
 
       emit delegateSuccess(delegator, validator, amount);
-      payable(TOKEN_HUB_ADDR).transfer(amount);
-    } else if (status == 0) {
+    } else if (status == CODE_FAILED) {
       undelegated[delegator] = undelegated[delegator].add(amount);
+      require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw bnb failed");
+
       emit delegateFailed(delegator, validator, amount, errCode);
     } else {
       revert("wrong status");
@@ -421,6 +450,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
     delegateInFly[delegator] -= 1;
     undelegated[delegator] = undelegated[delegator].add(amount);
+    require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw bnb failed");
 
     emit crashResponse(EVENT_DELEGATE);
   }
@@ -448,15 +478,14 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
     undelegateInFly[delegator] -= 1;
-    if (status == 1) {
+    if (status == CODE_SUCCESS) {
       require(errCode == 0, "wrong status");
       delegated[delegator] = delegated[delegator].sub(amount);
       delegatedOfValidator[delegator][validator] = delegatedOfValidator[delegator][validator].sub(amount);
       pendingUndelegateTime[delegator][validator] = block.timestamp.add(LOCK_TIME);
-      require(ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount), "withdraw BNB failed");
 
       emit undelegateSuccess(delegator, validator, amount);
-    } else if (status == 0) {
+    } else if (status == CODE_FAILED) {
       pendingUndelegateTime[delegator][validator] = 0;
       emit undelegateFailed(delegator, validator, amount, errCode);
     } else {
@@ -517,7 +546,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     uint256 amount = bcAmount.mul(TEN_DECIMALS);
     redelegateInFly[delegator] -= 1;
-    if (status == 1) {
+    if (status == CODE_SUCCESS) {
       require(errCode == 0, "wrong status");
       delegatedOfValidator[delegator][valSrc] = delegatedOfValidator[delegator][valSrc].sub(amount);
       delegatedOfValidator[delegator][valDst] = delegatedOfValidator[delegator][valDst].add(amount);
@@ -525,7 +554,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       pendingRedelegateTime[delegator][valDst][valSrc] = block.timestamp.add(LOCK_TIME);
 
       emit redelegateSuccess(delegator, valSrc, valDst, amount);
-    } else if (status == 0) {
+    } else if (status == CODE_FAILED) {
       pendingRedelegateTime[delegator][valSrc][valDst] = 0;
       pendingRedelegateTime[delegator][valDst][valSrc] = 0;
       emit redelegateFailed(delegator, valSrc, valDst, amount, errCode);
@@ -581,13 +610,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       }
       ++idx;
     }
-    if (!success) {
-      return _encodeRefundPackage(EVENT_DISTRIBUTE_REWARD, amount, recipient, ERROR_FAIL_DECODE);
-    }
+    require(success, "rlp decode failed");
 
     bool ok = ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount);
     if (!ok) {
-      return _encodeRefundPackage(EVENT_DISTRIBUTE_REWARD, amount, recipient, ERROR_WITHDRAW_BNB);
+      return _encodeRefundPackage(EVENT_DISTRIBUTE_REWARD, recipient, amount, ERROR_WITHDRAW_BNB);
     }
 
     distributedReward[recipient] = distributedReward[recipient].add(amount);
@@ -615,13 +642,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       }
       ++idx;
     }
-    if (!success) {
-      return _encodeRefundPackage(EVENT_DISTRIBUTE_UNDELEGATED, amount, recipient, ERROR_FAIL_DECODE);
-    }
+    require(success, "rlp decode failed");
 
     bool ok = ITokenHub(TOKEN_HUB_ADDR).withdrawStakingBNB(amount);
     if (!ok) {
-      return _encodeRefundPackage(EVENT_DISTRIBUTE_UNDELEGATED, amount, recipient, ERROR_WITHDRAW_BNB);
+      return _encodeRefundPackage(EVENT_DISTRIBUTE_UNDELEGATED, recipient, amount, ERROR_WITHDRAW_BNB);
     }
 
     pendingUndelegateTime[recipient][validator] = 0;
@@ -629,18 +654,5 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     emit undelegatedReceived(recipient, validator, amount);
     return (CODE_OK, new bytes(0));
-  }
-
-  function _checkPackHash(bytes memory packBytes) internal returns(bool){
-    bytes32 revHash = keccak256(packBytes);
-    bytes32 expHash = packageQueue[leftIndex];
-    for (uint i;i<32;++i) {
-      if (revHash[i] != expHash[i]) {
-        return false;
-      }
-    }
-    delete packageQueue[leftIndex];
-    ++leftIndex;
-    return true;
   }
 }

--- a/contracts/interface/IStaking.sol
+++ b/contracts/interface/IStaking.sol
@@ -28,5 +28,5 @@ interface IStaking {
 
   function getMinDelegation() external view returns(uint256);
 
-  function getRequestInFly() external view returns(uint256[3] memory);
+  function getRequestInFly(address delegator) external view returns(uint256[3] memory);
 }

--- a/contracts/interface/IStaking.sol
+++ b/contracts/interface/IStaking.sol
@@ -24,7 +24,7 @@ interface IStaking {
 
   function getPendingUndelegateTime(address delegator, address validator) external view returns(uint256);
 
-  function getOracleRelayerFee() external view returns(uint256);
+  function getRelayerFee() external view returns(uint256);
 
   function getMinDelegation() external view returns(uint256);
 

--- a/contracts/interface/IStaking.sol
+++ b/contracts/interface/IStaking.sol
@@ -10,7 +10,7 @@ interface IStaking {
 
   function claimReward() external returns(uint256);
 
-  function claimUndeldegated() external returns(uint256);
+  function claimUndelegated() external returns(uint256);
 
   function getDelegated(address delegator, address validator) external view returns(uint256);
 
@@ -27,4 +27,6 @@ interface IStaking {
   function getOracleRelayerFee() external view returns(uint256);
 
   function getMinDelegation() external view returns(uint256);
+
+  function getRequestInFly() external view returns(uint256[3] memory);
 }


### PR DESCRIPTION
### Description

There may be some vulnerability in previous native staking design. 

### Rationale

N/A

### Example

For example, if a user sends the `delegate` transaction with invalid validator, execute the `undelegate` transaction immediately before receiving the AckPackage of the last delegate transaction, the token from the last delegate transaction will be locked.

### Changes

For now, every request from BSC to BC will have an ack package to inform the status of the request. State changes will be done only after the ack package with success status is received.
