### PR TITLE
fix(BEP-171): modify params length to 2 for uint16

### DIFF
--- a/contracts/CrossChain.sol
+++ b/contracts/CrossChain.sol
@@ -414,17 +414,17 @@ contract CrossChain is System, ICrossChain, IParamSubscriber{
       }
     } else if (Memory.compareStrings(key, "suspendQuorum")) {
       require(value.length == 2, "length of value for suspendQuorum should be 2");
-      uint16 suspendQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 suspendQuorum = BytesToTypes.bytesToUint16(2, value);
       require(suspendQuorum > 0 && suspendQuorum < 100, "invalid suspend quorum");
       quorumMap[SUSPEND_PROPOSAL] = suspendQuorum;
     } else if (Memory.compareStrings(key, "reopenQuorum")) {
       require(value.length == 2, "length of value for reopenQuorum should be 2");
-      uint16 reopenQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 reopenQuorum = BytesToTypes.bytesToUint16(2, value);
       require(reopenQuorum > 0 && reopenQuorum < 100, "invalid reopen quorum");
       quorumMap[REOPEN_PROPOSAL] = reopenQuorum;
     } else if (Memory.compareStrings(key, "cancelTransferQuorum")) {
       require(value.length == 2, "length of value for cancelTransferQuorum should be 2");
-      uint16 cancelTransferQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 cancelTransferQuorum = BytesToTypes.bytesToUint16(2, value);
       require(cancelTransferQuorum > 0 && cancelTransferQuorum < 100, "invalid cancel transfer quorum");
       quorumMap[CANCEL_TRANSFER_PROPOSAL] = cancelTransferQuorum;
     } else {

--- a/contracts/CrossChain.template
+++ b/contracts/CrossChain.template
@@ -415,17 +415,17 @@ contract CrossChain is System, ICrossChain, IParamSubscriber{
       }
     } else if (Memory.compareStrings(key, "suspendQuorum")) {
       require(value.length == 2, "length of value for suspendQuorum should be 2");
-      uint16 suspendQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 suspendQuorum = BytesToTypes.bytesToUint16(2, value);
       require(suspendQuorum > 0 && suspendQuorum < 100, "invalid suspend quorum");
       quorumMap[SUSPEND_PROPOSAL] = suspendQuorum;
     } else if (Memory.compareStrings(key, "reopenQuorum")) {
       require(value.length == 2, "length of value for reopenQuorum should be 2");
-      uint16 reopenQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 reopenQuorum = BytesToTypes.bytesToUint16(2, value);
       require(reopenQuorum > 0 && reopenQuorum < 100, "invalid reopen quorum");
       quorumMap[REOPEN_PROPOSAL] = reopenQuorum;
     } else if (Memory.compareStrings(key, "cancelTransferQuorum")) {
       require(value.length == 2, "length of value for cancelTransferQuorum should be 2");
-      uint16 cancelTransferQuorum = BytesToTypes.bytesToUint16(32, value);
+      uint16 cancelTransferQuorum = BytesToTypes.bytesToUint16(2, value);
       require(cancelTransferQuorum > 0 && cancelTransferQuorum < 100, "invalid cancel transfer quorum");
       quorumMap[CANCEL_TRANSFER_PROPOSAL] = cancelTransferQuorum;
     } else {


### PR DESCRIPTION
### Description

This is a fix that update gov param for BEP-171

### Rationale
in the previous code, `BytesToTypes.bytesToUint16(32, value)` for uint16 will not be correctly set while input a bytes2 param.   
set `BytesToTypes.bytesToUint16(2, value)` for uint16 params

### Changes

Notable changes: 
* set `BytesToTypes.bytesToUint16(2, value)` for uint16 params
