### PR TITLE
Relayer admin bugfix

### DIFF
--- a/contracts/RelayerHub.sol
+++ b/contracts/RelayerHub.sol
@@ -163,7 +163,9 @@ contract RelayerHub is IRelayerHub, System, IParamSubscriber {
     // in case of removal we can simply update it to a non-existing account
     function updateRelayer(address relayerToBeAdded) public onlyRegisteredManager {
         // todo this is a bug which the current test doesn't capture. Write test which captures this and then add separate case for 0 address
-        require(!currentRelayers[relayerToBeAdded], "relayer already exists");
+        if (relayerToBeAdded != address(0)){
+            require(!currentRelayers[relayerToBeAdded], "relayer already exists");
+        }
         require(!isContract(relayerToBeAdded), "contract is not allowed to be a relayer");
 
         address oldRelayer = managerToRelayer[msg.sender];

--- a/contracts/RelayerHub.sol
+++ b/contracts/RelayerHub.sol
@@ -162,6 +162,7 @@ contract RelayerHub is IRelayerHub, System, IParamSubscriber {
     // updateRelayer() can be used to add relayer for the first time, update it in future and remove it
     // in case of removal we can simply update it to a non-existing account
     function updateRelayer(address relayerToBeAdded) public onlyRegisteredManager {
+        // todo this is a bug which the current test doesn't capture. Write test which captures this and then add separate case for 0 address
         require(!currentRelayers[relayerToBeAdded], "relayer already exists");
         require(!isContract(relayerToBeAdded), "contract is not allowed to be a relayer");
 

--- a/contracts/RelayerHub.sol
+++ b/contracts/RelayerHub.sol
@@ -162,8 +162,7 @@ contract RelayerHub is IRelayerHub, System, IParamSubscriber {
     // updateRelayer() can be used to add relayer for the first time, update it in future and remove it
     // in case of removal we can simply update it to a non-existing account
     function updateRelayer(address relayerToBeAdded) public onlyRegisteredManager {
-        // todo this is a bug which the current test doesn't capture. Write test which captures this and then add separate case for 0 address
-        if (relayerToBeAdded != address(0)){
+        if (relayerToBeAdded != address(0)) {
             require(!currentRelayers[relayerToBeAdded], "relayer already exists");
         }
         require(!isContract(relayerToBeAdded), "contract is not allowed to be a relayer");

--- a/lib/interface/IRelayerHub.sol
+++ b/lib/interface/IRelayerHub.sol
@@ -40,4 +40,5 @@ interface RelayerHub {
     function isManager(address relayerAddress) external view returns (bool);
     function removeManagerByHimself() external;
     function whitelistInit() external;
+    function updateRelayer(address relayerToBeAdded) public;
 }

--- a/lib/interface/IRelayerHub.sol
+++ b/lib/interface/IRelayerHub.sol
@@ -1,9 +1,13 @@
 pragma solidity ^0.8.10;
 
 interface RelayerHub {
+    event addManagerByGovEvent(address _addedManager);
     event paramChange(string key, bytes value);
+    event registerManagerEvent(address _registeredManager);
     event relayerRegister(address _relayer);
     event relayerUnRegister(address _relayer);
+    event removeManagerEvent(address _removedManager);
+    event updateRelayerEvent(address _from, address _to);
 
     function BIND_CHANNELID() external view returns (uint8);
     function CODE_OK() external view returns (uint32);
@@ -27,18 +31,21 @@ interface RelayerHub {
     function TRANSFER_IN_CHANNELID() external view returns (uint8);
     function TRANSFER_OUT_CHANNELID() external view returns (uint8);
     function VALIDATOR_CONTRACT_ADDR() external view returns (address);
+    function WHITELIST_1() external view returns (address);
+    function WHITELIST_2() external view returns (address);
     function alreadyInit() external view returns (bool);
     function bscChainID() external view returns (uint16);
     function dues() external view returns (uint256);
     function init() external;
-    function isRelayer(address sender) external view returns (bool);
-    function register() external payable;
+    function isManager(address relayerAddress) external view returns (bool);
+    function isRelayer(address relayerAddress) external view returns (bool);
+    function registerManagerAddRelayer(address r) external payable;
+    function removeManagerByHimself() external;
     function requiredDeposit() external view returns (uint256);
     function unregister() external;
     function updateParam(string memory key, bytes memory value) external;
-    function registerManagerAddRelayer(address r) external payable;
-    function isManager(address relayerAddress) external view returns (bool);
-    function removeManagerByHimself() external;
+    function updateRelayer(address relayerToBeAdded) external;
     function whitelistInit() external;
-    function updateRelayer(address relayerToBeAdded) public;
+    function whitelistInitDone() external view returns (bool);
 }
+


### PR DESCRIPTION
There was a bug where if a 2 managers register their relayers and 1 of them sets it to 0 and then the other one tries to set it to 0 then it won't work.

The setting to address(0) part needed special handling, so the require check is not required for this. 

This PR adds a test(`testRelayerAddingRemoving2()`) which captures that bug and then it is fixed.