### PR TITLE
chore: remove slash methods for fast finality

### DIFF
--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -4,7 +4,6 @@ pragma experimental ABIEncoderV2;
 import "./System.sol";
 import "./lib/BytesToTypes.sol";
 import "./lib/TypesToBytes.sol";
-import "./lib/BytesLib.sol";
 import "./lib/Memory.sol";
 import "./interface/ISlashIndicator.sol";
 import "./interface/IApplication.sol";
@@ -52,21 +51,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     uint256 height;
     uint256 count;
     bool exist;
-  }
-
-  // Proof that a validator misbehaved in fast finality
-  struct VoteData {
-    uint256 srcNum;
-    bytes32 srcHash;
-    uint256 tarNum;
-    bytes32 tarHash;
-    bytes sig;
-  }
-
-  struct FinalityEvidence {
-    VoteData voteA;
-    VoteData voteB;
-    bytes voteAddr;
   }
 
   modifier oncePerBlock() {
@@ -194,46 +178,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     emit indicatorCleaned();
   }
 
-  function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
-    if (finalitySlashRewardRatio == 0) {
-      finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
-    }
-
-    // Basic check
-    require(_evidence.voteA.srcNum+256 > block.number &&
-      _evidence.voteB.srcNum+256 > block.number, "too old block involved");
-    require(!(_evidence.voteA.srcHash == _evidence.voteB.srcHash &&
-      _evidence.voteA.tarHash == _evidence.voteB.tarHash), "two identical votes");
-    require(_evidence.voteA.srcNum < _evidence.voteA.tarNum &&
-      _evidence.voteB.srcNum < _evidence.voteB.tarNum, "srcNum bigger than tarNum");
-
-    // Vote rules check
-    require((_evidence.voteA.srcNum<_evidence.voteB.srcNum && _evidence.voteB.tarNum<_evidence.voteA.tarNum) ||
-      (_evidence.voteB.srcNum<_evidence.voteA.srcNum && _evidence.voteA.tarNum<_evidence.voteB.tarNum) ||
-      _evidence.voteA.tarNum == _evidence.voteB.tarNum, "no violation of vote rules");
-
-    // BLS verification
-    (address[] memory vals, bytes[] memory voteAddrs) = IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
-    address valAddr;
-    bytes memory voteAddr = _evidence.voteAddr;
-    for (uint i; i < voteAddrs.length; ++i) {
-      if (BytesLib.equal(voteAddrs[i],  voteAddr)) {
-        valAddr = vals[i];
-        break;
-      }
-    }
-    require(valAddr != address(0), "validator not exist");
-
-    require(verifyBLSSignature(_evidence.voteA, _evidence.voteAddr) &&
-      verifyBLSSignature(_evidence.voteB, _evidence.voteAddr), "verify signature failed");
-
-    uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * finalitySlashRewardRatio) / 100;
-    ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
-    IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valAddr);
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeSlashPackage(valAddr), 0);
-    emit validatorSlashed(valAddr);
-  }
-
   /**
    * @dev Send a felony cross-chain package to jail a validator
    *
@@ -241,45 +185,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
    */
   function sendFelonyPackage(address validator) external override(ISlashIndicator) onlyValidatorContract onlyInit {
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeSlashPackage(validator), 0);
-  }
-
-  function verifyBLSSignature(VoteData memory vote, bytes memory voteAddr) internal view returns(bool) {
-    bytes[] memory elements = new bytes[](4);
-    bytes memory _bytes = new bytes(32);
-    elements[0] = vote.srcNum.encodeUint();
-    TypesToBytes.bytes32ToBytes(32, vote.srcHash, _bytes);
-    elements[1] = _bytes.encodeBytes();
-    elements[2] = vote.tarNum.encodeUint();
-    TypesToBytes.bytes32ToBytes(32, vote.tarHash, _bytes);
-    elements[3] = _bytes.encodeBytes();
-
-    TypesToBytes.bytes32ToBytes(32, keccak256(elements.encodeList()), _bytes);
-
-    // assemble input data
-    bytes memory input = new bytes(176);
-    bytesConcat(input, _bytes, 0, 32);
-    bytesConcat(input, vote.sig, 32, 96);
-    bytesConcat(input, voteAddr, 128, 48);
-
-    // call the precompiled contract to verify the BLS signature
-    // the precompiled contract's address is 0x66
-    bytes memory output = new bytes(1);
-    assembly {
-      let len := mload(input)
-      if iszero(staticcall(not(0), 0x66, add(input, 0x20), len, add(output, 0x20), 0x01)) {
-        revert(0, 0)
-      }
-    }
-    if (BytesLib.toUint8(output, 0) != uint8(1)) {
-      return false;
-    }
-    return true;
-  }
-
-  function bytesConcat(bytes memory data, bytes memory _bytes, uint256 index, uint256 len) internal pure {
-    for (uint i; i<len; ++i) {
-      data[index++] = _bytes[i];
-    }
   }
 
   /*********************** Param update ********************************/

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -4,7 +4,6 @@ pragma experimental ABIEncoderV2;
 import "./System.sol";
 import "./lib/BytesToTypes.sol";
 import "./lib/TypesToBytes.sol";
-import "./lib/BytesLib.sol";
 import "./lib/Memory.sol";
 import "./interface/ISlashIndicator.sol";
 import "./interface/IApplication.sol";
@@ -52,21 +51,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     uint256 height;
     uint256 count;
     bool exist;
-  }
-
-  // Proof that a validator misbehaved in fast finality
-  struct VoteData {
-    uint256 srcNum;
-    bytes32 srcHash;
-    uint256 tarNum;
-    bytes32 tarHash;
-    bytes sig;
-  }
-
-  struct FinalityEvidence {
-    VoteData voteA;
-    VoteData voteB;
-    bytes voteAddr;
   }
 
   modifier oncePerBlock() {
@@ -199,46 +183,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     emit indicatorCleaned();
   }
 
-  function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
-    if (finalitySlashRewardRatio == 0) {
-      finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
-    }
-
-    // Basic check
-    require(_evidence.voteA.srcNum+256 > block.number &&
-      _evidence.voteB.srcNum+256 > block.number, "too old block involved");
-    require(!(_evidence.voteA.srcHash == _evidence.voteB.srcHash &&
-      _evidence.voteA.tarHash == _evidence.voteB.tarHash), "two identical votes");
-    require(_evidence.voteA.srcNum < _evidence.voteA.tarNum &&
-      _evidence.voteB.srcNum < _evidence.voteB.tarNum, "srcNum bigger than tarNum");
-
-    // Vote rules check
-    require((_evidence.voteA.srcNum<_evidence.voteB.srcNum && _evidence.voteB.tarNum<_evidence.voteA.tarNum) ||
-      (_evidence.voteB.srcNum<_evidence.voteA.srcNum && _evidence.voteA.tarNum<_evidence.voteB.tarNum) ||
-      _evidence.voteA.tarNum == _evidence.voteB.tarNum, "no violation of vote rules");
-
-    // BLS verification
-    (address[] memory vals, bytes[] memory voteAddrs) = IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
-    address valAddr;
-    bytes memory voteAddr = _evidence.voteAddr;
-    for (uint i; i < voteAddrs.length; ++i) {
-      if (BytesLib.equal(voteAddrs[i],  voteAddr)) {
-        valAddr = vals[i];
-        break;
-      }
-    }
-    require(valAddr != address(0), "validator not exist");
-
-    require(verifyBLSSignature(_evidence.voteA, _evidence.voteAddr) &&
-      verifyBLSSignature(_evidence.voteB, _evidence.voteAddr), "verify signature failed");
-
-    uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * finalitySlashRewardRatio) / 100;
-    ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
-    IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valAddr);
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeSlashPackage(valAddr), 0);
-    emit validatorSlashed(valAddr);
-  }
-
   /**
    * @dev Send a felony cross-chain package to jail a validator
    *
@@ -246,45 +190,6 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
    */
   function sendFelonyPackage(address validator) external override(ISlashIndicator) onlyValidatorContract onlyInit {
     ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeSlashPackage(validator), 0);
-  }
-
-  function verifyBLSSignature(VoteData memory vote, bytes memory voteAddr) internal view returns(bool) {
-    bytes[] memory elements = new bytes[](4);
-    bytes memory _bytes = new bytes(32);
-    elements[0] = vote.srcNum.encodeUint();
-    TypesToBytes.bytes32ToBytes(32, vote.srcHash, _bytes);
-    elements[1] = _bytes.encodeBytes();
-    elements[2] = vote.tarNum.encodeUint();
-    TypesToBytes.bytes32ToBytes(32, vote.tarHash, _bytes);
-    elements[3] = _bytes.encodeBytes();
-
-    TypesToBytes.bytes32ToBytes(32, keccak256(elements.encodeList()), _bytes);
-
-    // assemble input data
-    bytes memory input = new bytes(176);
-    bytesConcat(input, _bytes, 0, 32);
-    bytesConcat(input, vote.sig, 32, 96);
-    bytesConcat(input, voteAddr, 128, 48);
-
-    // call the precompiled contract to verify the BLS signature
-    // the precompiled contract's address is 0x66
-    bytes memory output = new bytes(1);
-    assembly {
-      let len := mload(input)
-      if iszero(staticcall(not(0), 0x66, add(input, 0x20), len, add(output, 0x20), 0x01)) {
-        revert(0, 0)
-      }
-    }
-    if (BytesLib.toUint8(output, 0) != uint8(1)) {
-      return false;
-    }
-    return true;
-  }
-
-  function bytesConcat(bytes memory data, bytes memory _bytes, uint256 index, uint256 len) internal pure {
-    for (uint i; i<len; ++i) {
-      data[index++] = _bytes[i];
-    }
   }
 
   /*********************** Param update ********************************/

--- a/test/SlashIndicator.t.sol
+++ b/test/SlashIndicator.t.sol
@@ -4,7 +4,6 @@ import "../lib/Deployer.sol";
 
 contract SlashIndicatorTest is Deployer {
   event validatorSlashed(address indexed validator);
-  event indicatorCleaned();
   event paramChange(string key, bytes value);
 
   address public coinbase;
@@ -265,42 +264,4 @@ contract SlashIndicatorTest is Deployer {
       }
     }
   }
-
-  //  function testFinality() public {
-  //    address[] memory vals = new address[](20);
-  //    bytes[] memory voteAddrs = new bytes[](20);
-  //    for (uint256 i; i < vals.length; ++i) {
-  //      vals[i] = addrSet[addrIdx++];
-  //      voteAddrs[i] = abi.encodePacked(vals[i]);
-  //    }
-  //    vm.prank(address(crossChain));
-  //    validator.handleSynPackage(STAKING_CHANNELID, encodeNewValidatorSetUpdatePack(0x00, vals, voteAddrs));
-  //
-  //    // case1: valid finality evidence: same target block
-  //    uint256 srcNumA = block.number - 20;
-  //    uint256 tarNumA = block.number - 10;
-  //    uint256 srcNumB = block.number - 15;
-  //    uint256 tarNumB = tarNumA;
-  //    SlashIndicator.VoteData memory voteA;
-  //    voteA.srcNum = srcNumA;
-  //    voteA.srcHash = blockhash(srcNumA);
-  //    voteA.tarNum = tarNumA;
-  //    voteA.tarHash = blockhash(tarNumA);
-  //    voteA.sig = abi.encode("sigA");
-  //
-  //    SlashIndicator.VoteData memory voteB;
-  //    voteB.srcNum = srcNumB;
-  //    voteB.srcHash = blockhash(srcNumB);
-  //    voteB.tarNum = tarNumB;
-  //    voteB.tarHash = blockhash(tarNumB);
-  //    voteB.sig = abi.encode("sigB");
-  //
-  //    SlashIndicator.FinalityEvidence memory evidence;
-  //    evidence.voteA = voteA;
-  //    evidence.voteB = voteB;
-  //    evidence.voteAddr = voteAddrs[0];
-  //
-  //    vm.prank(relayer);
-  //    slash.submitFinalityViolationEvidence(evidence);
-  //  }
 }


### PR DESCRIPTION
### Description

This pr is to remove slash methods for fast finality as we don't need that any longer.

### Changes

Notable changes:
* remove slash methods for fast finality