### PR TITLE
fix: slash more bnbs for malicious vote and no matter whether slashed validator is active.

### DIFF
--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -551,6 +551,8 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
     if (balanceOfSystemReward > MAX_SYSTEM_REWARD_BALANCE) {
       totalValue = balanceOfSystemReward.div(100);
     } else if (balanceOfSystemReward > previousBalanceOfSystemReward) {
+      // when a slash happens, theres will no rewards in some epoches,
+      // it's tolerated because slash happens rarely
       totalValue = (balanceOfSystemReward.sub(previousBalanceOfSystemReward)).mul(finalityRewardRatio).div(100);
     } else {
       return;

--- a/contracts/BSCValidatorSet.template
+++ b/contracts/BSCValidatorSet.template
@@ -551,6 +551,8 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
     if (balanceOfSystemReward > MAX_SYSTEM_REWARD_BALANCE) {
       totalValue = balanceOfSystemReward.div(100);
     } else if (balanceOfSystemReward > previousBalanceOfSystemReward) {
+      // when a slash happens, theres will no rewards in some epoches,
+      // it's tolerated because slash happens rarely
       totalValue = (balanceOfSystemReward.sub(previousBalanceOfSystemReward)).mul(finalityRewardRatio).div(100);
     } else {
       return;

--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -37,6 +37,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   uint256 public constant INIT_FINALITY_SLASH_REWARD_RATIO = 20;
 
   uint256 public finalitySlashRewardRatio;
+  uint256 public enableMaliciousVoteSlash;
 
   event validatorSlashed(address indexed validator);
   event maliciousVoteSlashed(bytes32 indexed voteAddrSlice);
@@ -197,6 +198,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   }
 
   function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
+    require(enableMaliciousVoteSlash > 0, "malicious vote slash not enabled");
     if (finalitySlashRewardRatio == 0) {
       finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
     }
@@ -304,6 +306,9 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       uint256 newFinalitySlashRewardRatio = BytesToTypes.bytesToUint256(32, value);
       require(newFinalitySlashRewardRatio >= 10 && newFinalitySlashRewardRatio < 100, "the finality slash reward ratio out of range");
       finalitySlashRewardRatio = newFinalitySlashRewardRatio;
+    } else if (Memory.compareStrings(key, "enableMaliciousVoteSlash")) {
+      require(value.length == 32, "length of enableMaliciousVoteSlash mismatch");
+      enableMaliciousVoteSlash = BytesToTypes.bytesToUint256(32, value);
     } else {
       require(false, "unknown param");
     }

--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -48,7 +48,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   event crashResponse();
 
   event failedFelony(address indexed validator, uint256 slashCount, bytes failReason);
-  event failedVoteSlash(bytes32 indexed voteAddrSlice, bytes failReason);
+  event failedMaliciousVoteSlash(bytes32 indexed voteAddrSlice, bytes failReason);
 
   struct Indicator {
     uint256 height;
@@ -234,7 +234,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     try ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeVoteSlashPackage(_evidence.voteAddr), 0) {
       emit maliciousVoteSlashed(voteAddrSlice);
     } catch (bytes memory reason) {
-      emit failedVoteSlash(voteAddrSlice, reason);
+      emit failedMaliciousVoteSlash(voteAddrSlice, reason);
     }
   }
 

--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -37,7 +37,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   uint256 public constant INIT_FINALITY_SLASH_REWARD_RATIO = 20;
 
   uint256 public finalitySlashRewardRatio;
-  uint256 public enableMaliciousVoteSlash;
+  bool public enableMaliciousVoteSlash;
 
   event validatorSlashed(address indexed validator);
   event maliciousVoteSlashed(bytes32 indexed voteAddrSlice);
@@ -198,7 +198,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   }
 
   function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
-    require(enableMaliciousVoteSlash > 0, "malicious vote slash not enabled");
+    require(enableMaliciousVoteSlash, "malicious vote slash not enabled");
     if (finalitySlashRewardRatio == 0) {
       finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
     }
@@ -308,7 +308,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       finalitySlashRewardRatio = newFinalitySlashRewardRatio;
     } else if (Memory.compareStrings(key, "enableMaliciousVoteSlash")) {
       require(value.length == 32, "length of enableMaliciousVoteSlash mismatch");
-      enableMaliciousVoteSlash = BytesToTypes.bytesToUint256(32, value);
+      enableMaliciousVoteSlash = BytesToTypes.bytesToBool(32, value);
     } else {
       require(false, "unknown param");
     }

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -37,6 +37,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   uint256 public constant INIT_FINALITY_SLASH_REWARD_RATIO = 20;
 
   uint256 public finalitySlashRewardRatio;
+  uint256 public enableMaliciousVoteSlash;
 
   event validatorSlashed(address indexed validator);
   event maliciousVoteSlashed(bytes32 indexed voteAddrSlice);
@@ -202,6 +203,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   }
 
   function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
+    require(enableMaliciousVoteSlash > 0, "malicious vote slash not enabled");
     if (finalitySlashRewardRatio == 0) {
       finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
     }
@@ -308,6 +310,9 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       uint256 newFinalitySlashRewardRatio = BytesToTypes.bytesToUint256(32, value);
       require(newFinalitySlashRewardRatio >= 10 && newFinalitySlashRewardRatio < 100, "the finality slash reward ratio out of range");
       finalitySlashRewardRatio = newFinalitySlashRewardRatio;
+    } else if (Memory.compareStrings(key, "enableMaliciousVoteSlash")) {
+      require(value.length == 32, "length of enableMaliciousVoteSlash mismatch");
+      enableMaliciousVoteSlash = BytesToTypes.bytesToUint256(32, value);
     } else {
       require(false, "unknown param");
     }

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -48,6 +48,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   event crashResponse();
 
   event failedFelony(address indexed validator, uint256 slashCount, bytes failReason);
+  event failedMaliciousVoteSlash(bytes32 indexed voteAddrSlice, bytes failReason);
 
   struct Indicator {
     uint256 height;
@@ -238,7 +239,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     try ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeVoteSlashPackage(_evidence.voteAddr), 0) {
       emit maliciousVoteSlashed(voteAddrSlice);
     } catch (bytes memory reason) {
-      emit failedVoteSlash(voteAddrSlice, reason);
+      emit failedMaliciousVoteSlash(voteAddrSlice, reason);
     }
   }
 

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -37,7 +37,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   uint256 public constant INIT_FINALITY_SLASH_REWARD_RATIO = 20;
 
   uint256 public finalitySlashRewardRatio;
-  uint256 public enableMaliciousVoteSlash;
+  bool public enableMaliciousVoteSlash;
 
   event validatorSlashed(address indexed validator);
   event maliciousVoteSlashed(bytes32 indexed voteAddrSlice);
@@ -203,7 +203,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   }
 
   function submitFinalityViolationEvidence(FinalityEvidence memory _evidence) public onlyInit onlyRelayer {
-    require(enableMaliciousVoteSlash > 0, "malicious vote slash not enabled");
+    require(enableMaliciousVoteSlash, "malicious vote slash not enabled");
     if (finalitySlashRewardRatio == 0) {
       finalitySlashRewardRatio = INIT_FINALITY_SLASH_REWARD_RATIO;
     }
@@ -312,7 +312,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       finalitySlashRewardRatio = newFinalitySlashRewardRatio;
     } else if (Memory.compareStrings(key, "enableMaliciousVoteSlash")) {
       require(value.length == 32, "length of enableMaliciousVoteSlash mismatch");
-      enableMaliciousVoteSlash = BytesToTypes.bytesToUint256(32, value);
+      enableMaliciousVoteSlash = BytesToTypes.bytesToBool(32, value);
     } else {
       require(false, "unknown param");
     }

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -39,6 +39,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   uint256 public finalitySlashRewardRatio;
 
   event validatorSlashed(address indexed validator);
+  event maliciousVoteSlashed(bytes32 indexed voteAddrSlice);
   event indicatorCleaned();
   event paramChange(string key, bytes value);
 
@@ -218,25 +219,27 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       _evidence.voteA.tarNum == _evidence.voteB.tarNum, "no violation of vote rules");
 
     // BLS verification
-    (address[] memory vals, bytes[] memory voteAddrs) = IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
-    address valAddr;
-    bytes memory voteAddr = _evidence.voteAddr;
-    for (uint i; i < voteAddrs.length; ++i) {
-      if (BytesLib.equal(voteAddrs[i],  voteAddr)) {
-        valAddr = vals[i];
-        break;
-      }
-    }
-    require(valAddr != address(0), "validator not exist");
-
     require(verifyBLSSignature(_evidence.voteA, _evidence.voteAddr) &&
       verifyBLSSignature(_evidence.voteB, _evidence.voteAddr), "verify signature failed");
 
-    uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * finalitySlashRewardRatio) / 100;
-    ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
-    IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valAddr);
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeSlashPackage(valAddr), 0);
-    emit validatorSlashed(valAddr);
+    // reward sender and felony validator if validator found
+    (address[] memory vals, bytes[] memory voteAddrs) = IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
+    for (uint i; i < voteAddrs.length; ++i) {
+      if (BytesLib.equal(voteAddrs[i],  _evidence.voteAddr)) {
+        uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * finalitySlashRewardRatio) / 100;
+        ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
+        IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony( vals[i]);
+        break;
+      }
+    }
+
+    // send slash msg to bc
+    bytes32 voteAddrSlice = BytesLib.toBytes32(_evidence.voteAddr,0);
+    try ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(SLASH_CHANNELID, encodeVoteSlashPackage(_evidence.voteAddr), 0) {
+      emit maliciousVoteSlashed(voteAddrSlice);
+    } catch (bytes memory reason) {
+      emit failedVoteSlash(voteAddrSlice, reason);
+    }
   }
 
   /**
@@ -319,6 +322,15 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
   function encodeSlashPackage(address valAddr) internal view returns (bytes memory) {
     bytes[] memory elements = new bytes[](4);
     elements[0] = valAddr.encodeAddress();
+    elements[1] = uint256(block.number).encodeUint();
+    elements[2] = uint256(bscChainID).encodeUint();
+    elements[3] = uint256(block.timestamp).encodeUint();
+    return elements.encodeList();
+  }
+
+  function encodeVoteSlashPackage(bytes memory voteAddr) internal view returns (bytes memory) {
+    bytes[] memory elements = new bytes[](4);
+    elements[0] = voteAddr.encodeBytes();
     elements[1] = uint256(block.number).encodeUint();
     elements[2] = uint256(bscChainID).encodeUint();
     elements[3] = uint256(block.timestamp).encodeUint();


### PR DESCRIPTION
Description

malicious vote affects the safety of bsc seriously, 
so we need slash more BNBs for malicious vote and no matter whether slashed validator is active.

Rationale
1. after a validator generating a malicious vote, it can go down on purpose to avoid to be slashed.
	so we change the mechanism to slash it no matter whether it's active.
2. slash amount is 50 BNBs, more need to be slashed.
	so we send a different crosschain pack and handle it in bc node correspondingly 

Example
tested in new qa
N/A