### PR TITLE
fork: enable planckBlock by default

### DIFF
--- a/genesis-template.json
+++ b/genesis-template.json
@@ -18,8 +18,9 @@
     "eulerBlock": 2,
     "gibbsBlock": 3,
     "moranBlock": 4,
-    "bonehBlock": 5,
-    "lynnBlock": 6,
+    "planckBlock": 5,
+    "bonehBlock": 6,
+    "lynnBlock": 7,
     "parlia": {
       "period": 3,
       "epoch": 200


### PR DESCRIPTION
This PR is quite simple:

as we enable `planck` upgrade on both testnet and mainnet, we can enable it on local network by default.