### PR TITLE
rename: rename hardfork name to luban & plato

### DIFF
--- a/genesis-template.json
+++ b/genesis-template.json
@@ -19,8 +19,8 @@
     "gibbsBlock": 3,
     "moranBlock": 4,
     "planckBlock": 5,
-    "bonehBlock": 6,
-    "lynnBlock": 7,
+    "lubanBlock": 6,
+    "platoBlock": 7,
     "parlia": {
       "period": 3,
       "epoch": 200

--- a/genesis.json
+++ b/genesis.json
@@ -19,8 +19,8 @@
     "gibbsBlock": 3,
     "moranBlock": 4,
     "planckBlock": 5,
-    "bonehBlock": 6,
-    "lynnBlock": 7,
+    "lubanBlock": 6,
+    "platoBlock": 7,
     "parlia": {
       "period": 3,
       "epoch": 200


### PR DESCRIPTION
## description
This PR aims to rename the hardfork name, boneh and lynn will not be used any longer, will be replaced with luban and plato.

## Impact
No impact to users.