### PR TITLE
fix: wrong refund address in `updateValidatorSet` (#286)

### DIFF
--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -329,7 +329,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
           crossAddrs[crossSize] = currentValidatorSet[i].BBCFeeAddress;
           uint256 value = currentValidatorSet[i].incoming - currentValidatorSet[i].incoming % PRECISION;
           crossAmounts[crossSize] = value.sub(relayFee);
-          crossRefundAddrs[crossSize] = currentValidatorSet[i].BBCFeeAddress;
+          crossRefundAddrs[crossSize] = currentValidatorSet[i].feeAddress;
           crossIndexes[crossSize] = i;
           crossTotal = crossTotal.add(value);
           ++crossSize;

--- a/contracts/BSCValidatorSet.template
+++ b/contracts/BSCValidatorSet.template
@@ -329,7 +329,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
           crossAddrs[crossSize] = currentValidatorSet[i].BBCFeeAddress;
           uint256 value = currentValidatorSet[i].incoming - currentValidatorSet[i].incoming % PRECISION;
           crossAmounts[crossSize] = value.sub(relayFee);
-          crossRefundAddrs[crossSize] = currentValidatorSet[i].BBCFeeAddress;
+          crossRefundAddrs[crossSize] = currentValidatorSet[i].feeAddress;
           crossIndexes[crossSize] = i;
           crossTotal = crossTotal.add(value);
           ++crossSize;


### PR DESCRIPTION
## description

This PR aims to fix the wrong refund address assignment in `updateValidatorSet` function.

## Impact

No impact to users.