### PR TITLE
fix: protect validator from being slashed for malicious vote signed b…

### DIFF
--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -216,6 +216,9 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       (_evidence.voteB.srcNum<_evidence.voteA.srcNum && _evidence.voteA.tarNum<_evidence.voteB.tarNum) ||
       _evidence.voteA.tarNum == _evidence.voteB.tarNum, "no violation of vote rules");
 
+    // check voteAddr to protect validators from being slashed for old voteAddr
+    require(IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).isMonitoredForMaliciousVote(_evidence.voteAddr),"voteAddr is not found");
+
     // BLS verification
     require(verifyBLSSignature(_evidence.voteA, _evidence.voteAddr) &&
       verifyBLSSignature(_evidence.voteB, _evidence.voteAddr), "verify signature failed");

--- a/contracts/SlashIndicator.template
+++ b/contracts/SlashIndicator.template
@@ -221,6 +221,9 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
       (_evidence.voteB.srcNum<_evidence.voteA.srcNum && _evidence.voteA.tarNum<_evidence.voteB.tarNum) ||
       _evidence.voteA.tarNum == _evidence.voteB.tarNum, "no violation of vote rules");
 
+    // check voteAddr to protect validators from being slashed for old voteAddr
+    require(IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).isMonitoredForMaliciousVote(_evidence.voteAddr),"voteAddr is not found");
+
     // BLS verification
     require(verifyBLSSignature(_evidence.voteA, _evidence.voteAddr) &&
       verifyBLSSignature(_evidence.voteB, _evidence.voteAddr), "verify signature failed");

--- a/contracts/interface/IBSCValidatorSet.sol
+++ b/contracts/interface/IBSCValidatorSet.sol
@@ -7,4 +7,5 @@ interface IBSCValidatorSet {
   function isCurrentValidator(address validator) external view returns (bool);
   function getLivingValidators() external view returns(address[] memory, bytes[] memory);
   function getMiningValidators() external view returns(address[] memory, bytes[] memory);
+  function isMonitoredForMaliciousVote(bytes calldata voteAddr) external view returns (bool);
 }


### PR DESCRIPTION
## Description

for now,
validator can be slashed for malicious vote signed by verify old vote keys.
this PR limit that vote keys should be in last two validator set which come from breathe block.

## Changes

Notable changes:
* add each change in a bullet point here
* ...