### PR TITLE
improve rewards limit for fast finality

### DIFF
--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -561,7 +561,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
       return;
     }
 
-    totalValue = ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(payable(address(this)), totalValue);
+    totalValue = ISystemReward(SYSTEM_REWARD_ADDR).claimRewardsforFinality(payable(address(this)), totalValue);
     if (totalValue == 0) {
       return;
     }

--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -228,7 +228,7 @@ contract SlashIndicator is ISlashIndicator,System,IParamSubscriber, IApplication
     for (uint i; i < voteAddrs.length; ++i) {
       if (BytesLib.equal(voteAddrs[i],  _evidence.voteAddr)) {
         uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * finalitySlashRewardRatio) / 100;
-        ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
+        ISystemReward(SYSTEM_REWARD_ADDR).claimRewardsforFinality(msg.sender, amount);
         IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony( vals[i]);
         break;
       }

--- a/contracts/SystemReward.sol
+++ b/contracts/SystemReward.sol
@@ -6,7 +6,8 @@ import "./interface/IParamSubscriber.sol";
 import "./interface/ISystemReward.sol";
 
 contract SystemReward is System, IParamSubscriber, ISystemReward {
-  uint256 public constant MAX_REWARDS = 1e18;
+  uint256 public constant MAX_REWARDS/*_FOR_RELAYER*/ = 1e18;
+  uint256 public constant MAX_REWARDS_FOR_FINALITY = 5e18;
 
   uint public numOperator;
   mapping(address => bool) operators;
@@ -43,6 +44,20 @@ contract SystemReward is System, IParamSubscriber, ISystemReward {
     uint256 actualAmount = amount < address(this).balance ? amount : address(this).balance;
     if (actualAmount > MAX_REWARDS) {
       actualAmount = MAX_REWARDS;
+    }
+    if (actualAmount != 0) {
+      to.transfer(actualAmount);
+      emit rewardTo(to, actualAmount);
+    } else {
+      emit rewardEmpty();
+    }
+    return actualAmount;
+  }
+
+  function claimRewardsforFinality(address payable to, uint256 amount) external override(ISystemReward) doInit onlyOperator returns (uint256) {
+    uint256 actualAmount = amount < address(this).balance ? amount : address(this).balance;
+    if (actualAmount > MAX_REWARDS_FOR_FINALITY) {
+      actualAmount = MAX_REWARDS_FOR_FINALITY;
     }
     if (actualAmount != 0) {
       to.transfer(actualAmount);

--- a/contracts/TokenHub.sol
+++ b/contracts/TokenHub.sol
@@ -161,6 +161,10 @@ contract TokenHub is ITokenHub, System, IParamSubscriber, IApplication, ISystemR
     return actualAmount;
   }
 
+  function claimRewardsforFinality(address payable, uint256) onlyInit onlyRelayerIncentivize external override returns(uint256) {
+    revert("CLAIM_REWARDS_FOR_FINALITY_NOT_ALLOWED");
+  }
+
   function getMiniRelayFee() external view override returns(uint256) {
     return relayFee;
   }

--- a/contracts/interface/ISystemReward.sol
+++ b/contracts/interface/ISystemReward.sol
@@ -2,4 +2,5 @@ pragma solidity 0.6.4;
 
 interface ISystemReward {
   function claimRewards(address payable to, uint256 amount) external returns(uint256 actualAmount);
+  function claimRewardsforFinality(address payable to, uint256 amount) external returns(uint256 actualAmount);
 }


### PR DESCRIPTION
### Rational
system rewards is limited within 1BNB even if we improve the ratio to much higner for fast finality rewards, 
so in this PR, we improve the system rewards for fast finality seperately.

if fast finality rewards ratio is 25%, the limit `5BNB`has not been touched is the past year https://bscscan.com/chart/blocks


