### PR TITLE
init SystemReward for local test and add shanghaiTime,keplerTime

### DIFF
--- a/genesis-template.json
+++ b/genesis-template.json
@@ -24,7 +24,8 @@
     "berlinBlock": 8,
     "londonBlock": 8,
     "hertzBlock": 8,
-    "fusionBlock": 9,
+    "shanghaiTime": 0,
+    "keplerTime": 0,
     "parlia": {
       "period": 3,
       "epoch": 200

--- a/scripts/generate-tendermintLightClient.sh
+++ b/scripts/generate-tendermintLightClient.sh
@@ -2,12 +2,17 @@
 
 # Default values
 OUTPUT="./contracts/TendermintLightClient.sol"
+NETWORK=""
 INIT_CONSENSUS_STATE_BYTES="696e616e63652d436861696e2d4e696c650000000000000000000000000000000000000000000229eca254b3859bffefaf85f4c95da9fbd26527766b784272789c30ec56b380b6eb96442aaab207bc59978ba3dd477690f5c5872334fc39e627723daa97e441e88ba4515150ec3182bc82593df36f8abb25a619187fcfab7e552b94e64ed2deed000000e8d4a51000"
 REWARD_FOR_VALIDATOR_SET_CHANGE="1e16"
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+    --network)
+        NETWORK="$2"
+        shift
+        ;;
     --initConsensusStateBytes)
         INIT_CONSENSUS_STATE_BYTES="$2"
         shift
@@ -27,5 +32,13 @@ done
 # Replace the specific line
 sed -i -e "s/bytes constant public INIT_CONSENSUS_STATE_BYTES = .*;/bytes constant public INIT_CONSENSUS_STATE_BYTES = hex\"${INIT_CONSENSUS_STATE_BYTES}\";/g" "$OUTPUT"
 sed -i -e "s/uint256 constant public INIT_REWARD_FOR_VALIDATOR_SER_CHANGE  = .*;/uint256 constant public INIT_REWARD_FOR_VALIDATOR_SER_CHANGE  = ${REWARD_FOR_VALIDATOR_SET_CHANGE};/g" "$OUTPUT"
+
+case $NETWORK in
+local)
+    sed -i -e "s/alreadyInit = true;/ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(payable(address(this)), 0);\n\t\talreadyInit = true;/g" "$OUTPUT" # just to init SystemReward
+    ;;
+*)
+    ;;
+esac
 
 echo "TendermintLightClient file updated."

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -9,7 +9,7 @@ function generate_local() {
     bash ${basedir}/generate-system.sh --bscChainId 02ca
     bash ${basedir}/generate-crosschain.sh --bscChainId 02ca
     bash ${basedir}/generate-relayerHub.sh --network local
-    bash ${basedir}/generate-tendermintLightClient.sh --initConsensusStateBytes "42696e616e63652d436861696e2d4e696c650000000000000000000000000000000000000000000229eca254b3859bffefaf85f4c95da9fbd26527766b784272789c30ec56b380b6eb96442aaab207bc59978ba3dd477690f5c5872334fc39e627723daa97e441e88ba4515150ec3182bc82593df36f8abb25a619187fcfab7e552b94e64ed2deed000000e8d4a51000"
+    bash ${basedir}/generate-tendermintLightClient.sh --network local --initConsensusStateBytes "42696e616e63652d436861696e2d4e696c650000000000000000000000000000000000000000000229eca254b3859bffefaf85f4c95da9fbd26527766b784272789c30ec56b380b6eb96442aaab207bc59978ba3dd477690f5c5872334fc39e627723daa97e441e88ba4515150ec3182bc82593df36f8abb25a619187fcfab7e552b94e64ed2deed000000e8d4a51000"
     bash ${basedir}/generate-validatorSet.sh --initBurnRatio 1000 --network local
     bash ${basedir}/generate-systemReward.sh --network local
     bash ${basedir}/generate-slashIndicator.sh --network local


### PR DESCRIPTION
### Rational
1. unlike other system contracts, SystemReward has no function `init` , instead only have a modifier `doInit`,
   to deploy local test easily, we need to init SystemReward, `claimRewards` called once to do it
2. add  `shanghaiTime` and `keplerTime` in genesis.json
    set them to 0, meaning the same block with london hardfork
3. remove `fusionBlock` just for now, because related code is not merged,
   will run into wrong when work with other scripts.