### PR TITLE
fix: init params error in BSCGovernor

### DIFF
--- a/contracts/BC_fusion/BSCGovernor.sol
+++ b/contracts/BC_fusion/BSCGovernor.sol
@@ -32,16 +32,16 @@ contract BSCGovernor is
         @dev caution:
         INIT_VOTING_DELAY, INIT_VOTING_PERIOD and INIT_MIN_PERIOD_AFTER_QUORUM are default in number of blocks, not seconds
     */
-    uint256 private constant SECONDS_PER_BLOCK = 3 seconds;
-    uint256 private constant INIT_VOTING_DELAY = 24 hours / SECONDS_PER_BLOCK;
-    uint256 private constant INIT_VOTING_PERIOD = 14 days / SECONDS_PER_BLOCK;
+    uint256 private constant BLOCK_INTERVAL = 3 seconds;
+    uint256 private constant INIT_VOTING_DELAY = 24 hours / BLOCK_INTERVAL;
+    uint256 private constant INIT_VOTING_PERIOD = 14 days / BLOCK_INTERVAL;
     uint256 private constant INIT_PROPOSAL_THRESHOLD = 100 ether; //  = 100 BNB
     uint256 private constant INIT_QUORUM_NUMERATOR = 10; // for >= 10%
 
     // starting propose requires totalSupply of GovBNB >= 10000000 * 1e18
     uint256 private constant PROPOSE_START_GOVBNB_SUPPLY_THRESHOLD = 10_000_000 ether;
     // ensures there is a minimum voting period (1 days) after quorum is reached
-    uint64 private constant INIT_MIN_PERIOD_AFTER_QUORUM = uint64(1 days / SECONDS_PER_BLOCK);
+    uint64 private constant INIT_MIN_PERIOD_AFTER_QUORUM = uint64(1 days / BLOCK_INTERVAL);
 
     /*----------------- errors -----------------*/
     error NotWhitelisted();

--- a/contracts/BC_fusion/BSCGovernor.sol
+++ b/contracts/BC_fusion/BSCGovernor.sol
@@ -28,15 +28,20 @@ contract BSCGovernor is
     using Utils for string;
 
     /*----------------- constants -----------------*/
-    uint256 private constant INIT_VOTING_DELAY = 24 hours;
-    uint256 private constant INIT_VOTING_PERIOD = 14 days;
+    /*
+        @dev caution:
+        INIT_VOTING_DELAY, INIT_VOTING_PERIOD and INIT_MIN_PERIOD_AFTER_QUORUM are default in number of blocks, not seconds
+    */
+    uint256 private constant SECONDS_PER_BLOCK = 3 seconds;
+    uint256 private constant INIT_VOTING_DELAY = 24 hours / SECONDS_PER_BLOCK;
+    uint256 private constant INIT_VOTING_PERIOD = 14 days / SECONDS_PER_BLOCK;
     uint256 private constant INIT_PROPOSAL_THRESHOLD = 100 ether; //  = 100 BNB
     uint256 private constant INIT_QUORUM_NUMERATOR = 10; // for >= 10%
 
     // starting propose requires totalSupply of GovBNB >= 10000000 * 1e18
     uint256 private constant PROPOSE_START_GOVBNB_SUPPLY_THRESHOLD = 10_000_000 ether;
     // ensures there is a minimum voting period (1 days) after quorum is reached
-    uint64 private constant INIT_MIN_PERIOD_AFTER_QUORUM = uint64(1 days);
+    uint64 private constant INIT_MIN_PERIOD_AFTER_QUORUM = uint64(1 days / SECONDS_PER_BLOCK);
 
     /*----------------- errors -----------------*/
     error NotWhitelisted();

--- a/contracts/BC_fusion/BSCGovernor.sol
+++ b/contracts/BC_fusion/BSCGovernor.sol
@@ -81,21 +81,8 @@ contract BSCGovernor is
         __GovernorVotesQuorumFraction_init(INIT_QUORUM_NUMERATOR);
         __GovernorPreventLateQuorum_init(INIT_MIN_PERIOD_AFTER_QUORUM);
 
-        whitelistTargets[VALIDATOR_CONTRACT_ADDR] = true;
-        whitelistTargets[SLASH_CONTRACT_ADDR] = true;
-        whitelistTargets[SYSTEM_REWARD_ADDR] = true;
-        whitelistTargets[LIGHT_CLIENT_ADDR] = true;
-        whitelistTargets[TOKEN_HUB_ADDR] = true;
-        whitelistTargets[INCENTIVIZE_ADDR] = true;
-        whitelistTargets[RELAYERHUB_CONTRACT_ADDR] = true;
+        // BSCGovernor => Timelock => GovHub => system contracts
         whitelistTargets[GOV_HUB_ADDR] = true;
-        whitelistTargets[TOKEN_MANAGER_ADDR] = true;
-        whitelistTargets[CROSS_CHAIN_CONTRACT_ADDR] = true;
-        whitelistTargets[STAKING_CONTRACT_ADDR] = true;
-        whitelistTargets[STAKE_HUB_ADDR] = true;
-        whitelistTargets[GOVERNOR_ADDR] = true;
-        whitelistTargets[GOV_TOKEN_ADDR] = true;
-        whitelistTargets[TIMELOCK_ADDR] = true;
 
         governorProtector = address(0x000000000000000000000000000000000000dEaD); // TODO
     }

--- a/contracts/BC_fusion/BSCTimelock.sol
+++ b/contracts/BC_fusion/BSCTimelock.sol
@@ -11,6 +11,10 @@ contract BSCTimelock is System, Initializable, TimelockControllerUpgradeable {
     using Utils for string;
 
     /*----------------- constants -----------------*/
+    /*
+        @dev caution:
+        minDelay using second as unit
+    */
     uint256 private constant INIT_MINIMAL_DELAY = 24 hours;
 
     /*----------------- init -----------------*/

--- a/contracts/GovHub.sol
+++ b/contracts/GovHub.sol
@@ -51,7 +51,7 @@ contract GovHub is System, IApplication{
     require(false, "receive unexpected fail ack package");
   }
 
-  function updateParam(string calldata key, bytes calldata value, address target) external onlyGovernor {
+  function updateParam(string calldata key, bytes calldata value, address target) external onlyGovernorTimelock {
     ParamChangePackage memory proposal = ParamChangePackage(key, value, target);
     notifyUpdates(proposal);
   }

--- a/contracts/System.sol
+++ b/contracts/System.sol
@@ -3,7 +3,6 @@ pragma solidity 0.6.4;
 import "./interface/ISystemReward.sol";
 import "./interface/IRelayerHub.sol";
 import "./interface/ILightClient.sol";
-import "forge-std/console.sol";
 
 contract System {
 

--- a/contracts/System.sol
+++ b/contracts/System.sol
@@ -3,6 +3,7 @@ pragma solidity 0.6.4;
 import "./interface/ISystemReward.sol";
 import "./interface/IRelayerHub.sol";
 import "./interface/ILightClient.sol";
+import "forge-std/console.sol";
 
 contract System {
 
@@ -32,7 +33,10 @@ contract System {
   address public constant CROSS_CHAIN_CONTRACT_ADDR = 0x0000000000000000000000000000000000002000;
   address public constant STAKING_CONTRACT_ADDR = 0x0000000000000000000000000000000000002001;
   address public constant STAKE_HUB_ADDR = 0x0000000000000000000000000000000000002002;
+  address public constant STAKE_CREDIT_ADDR = 0x0000000000000000000000000000000000002003;
   address public constant GOVERNOR_ADDR = 0x0000000000000000000000000000000000002004;
+  address public constant GOV_TOKEN_ADDR = 0x0000000000000000000000000000000000002005;
+  address public constant TIMELOCK_ADDR = 0x0000000000000000000000000000000000002006;
   address public constant TOKEN_RECOVER_PORTAL_ADDR = 0x0000000000000000000000000000000000003000;
 
   modifier onlyCoinbase() {
@@ -100,8 +104,8 @@ contract System {
     _;
   }
 
-  modifier onlyGovernor() {
-      require(msg.sender == GOVERNOR_ADDR, "the msg sender must be governor contract");
+  modifier onlyGovernorTimelock() {
+      require(msg.sender == TIMELOCK_ADDR, "the msg sender must be governor timelock contract");
       _;
   }
 


### PR DESCRIPTION
## ChangeLog
- these params is default in number of block not seconds

```    
    uint256 private constant INIT_VOTING_DELAY = 24 hours / SECONDS_PER_BLOCK;
    uint256 private constant INIT_VOTING_PERIOD = 14 days / SECONDS_PER_BLOCK;
    uint64 private constant INIT_MIN_PERIOD_AFTER_QUORUM = uint64(1 days / SECONDS_PER_BLOCK);
```

- only allow `GovHub` in whitelist proposal targets, restrict permissions
- sync system contracts