### PR TITLE
chore: disable editing moniker

### DIFF
--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -354,20 +354,20 @@ contract StakeHub is System, Initializable {
     }
 
     /**
+     * @notice the moniker of the validator will be ignored as it is not editable
      * @param description the new description of the validator
      */
-    function editDescription(Description calldata description)
+    function editDescription(Description memory description)
         external
         whenNotPaused
         notInBlackList
         validatorExist(msg.sender)
     {
-        if (!_checkMoniker(description.moniker)) revert InvalidMoniker();
-
         address operatorAddress = msg.sender;
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATH_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
+        description.moniker = valInfo.description.moniker;
         valInfo.description = description;
         valInfo.updateTime = block.timestamp;
 

--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -67,30 +67,14 @@ contract StakeHubTest is Deployer {
         // 4. edit description
         vm.warp(block.timestamp + 1 days);
         StakeHub.Description memory description = stakeHub.getValidatorDescription(validator);
-        // invalid moniker
-        description.moniker = "test";
-        vm.expectRevert();
-        stakeHub.editDescription(description);
-
-        description.moniker = "T";
-        vm.expectRevert();
-        stakeHub.editDescription(description);
-
-        description.moniker = "Test;";
-        vm.expectRevert();
-        stakeHub.editDescription(description);
-
-        description.moniker = "Test ";
-        vm.expectRevert();
-        stakeHub.editDescription(description);
-
-        // valid moniker
         description.moniker = "Test";
+        description.website = "Test";
         vm.expectEmit(true, false, false, true, address(stakeHub));
         emit DescriptionEdited(validator);
         stakeHub.editDescription(description);
         StakeHub.Description memory realDesc = stakeHub.getValidatorDescription(validator);
-        assertEq(realDesc.moniker, "Test");
+        assertNotEq(realDesc.moniker, "Test"); // edit moniker is not allowed
+        assertEq(realDesc.website, "Test");
 
         // 5. edit vote address
         vm.warp(block.timestamp + 1 days);


### PR DESCRIPTION
### Description

This pr is to disable editing moniker in `StakeHub`

### Rationale

To ensure that moniker and token names remain consistent

### Changes

Notable changes: 
* disable editing moniker in `StakeHub`
