### PR TITLE
chore: revert transaction when delegator in blacklist

### DIFF
--- a/abi/bscgovernor.abi
+++ b/abi/bscgovernor.abi
@@ -1036,7 +1036,7 @@
     ],
     "outputs": [
       {
-        "name": "",
+        "name": "proposalId",
         "type": "uint256",
         "internalType": "uint256"
       }

--- a/abi/stakehub.abi
+++ b/abi/stakehub.abi
@@ -1202,10 +1202,10 @@
         "internalType": "uint256"
       },
       {
-        "name": "status",
+        "name": "respCode",
         "type": "uint8",
         "indexed": false,
-        "internalType": "enum StakeHub.StakeMigrationStatus"
+        "internalType": "enum StakeHub.StakeMigrationRespCode"
       }
     ],
     "anonymous": false

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -151,7 +151,6 @@ contract StakeHub is System, Initializable {
     enum StakeMigrationRespCode {
         MIGRATE_SUCCESS,
         CLAIM_FUND_FAILED,
-        ILLEGAL_DELEGATOR,
         VALIDATOR_NOT_EXISTED,
         VALIDATOR_JAILED,
         BALANCE_NOT_ENOUGH
@@ -1031,12 +1030,13 @@ contract StakeHub is System, Initializable {
         returns (StakeMigrationRespCode)
     {
         if (blackList[migrationPkg.delegator] || migrationPkg.delegator == address(0)) {
-            return StakeMigrationRespCode.ILLEGAL_DELEGATOR;
+            revert InBlackList();
         }
 
         if (!_validatorSet.contains(migrationPkg.operatorAddress)) {
             return StakeMigrationRespCode.VALIDATOR_NOT_EXISTED;
         }
+
         Validator memory valInfo = _validators[migrationPkg.operatorAddress];
         if (valInfo.jailed && migrationPkg.delegator != migrationPkg.operatorAddress) {
             return StakeMigrationRespCode.VALIDATOR_JAILED;

--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -31,7 +31,6 @@ contract StakeHubTest is Deployer {
     enum StakeMigrationRespCode {
         MIGRATE_SUCCESS,
         CLAIM_FUND_FAILED,
-        ILLEGAL_DELEGATOR,
         VALIDATOR_NOT_EXISTED,
         VALIDATOR_JAILED,
         BALANCE_NOT_ENOUGH

--- a/test/utils/interface/IBSCGovernor.sol
+++ b/test/utils/interface/IBSCGovernor.sol
@@ -188,7 +188,7 @@ interface BSCGovernor {
         uint256[] memory values,
         bytes[] memory calldatas,
         bytes32 descriptionHash
-    ) external returns (uint256);
+    ) external returns (uint256 proposalId);
     function queue(uint256 proposalId) external;
     function quorum(uint256 timepoint) external view returns (uint256);
     function quorumDenominator() external view returns (uint256);

--- a/test/utils/interface/IStakeHub.sol
+++ b/test/utils/interface/IStakeHub.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.10;
 
 interface StakeHub {
     type SlashType is uint8;
-    type StakeMigrationStatus is uint8;
+    type StakeMigrationRespCode is uint8;
 
     struct Commission {
         uint64 rate;
@@ -58,7 +58,7 @@ interface StakeHub {
     event DescriptionEdited(address indexed operatorAddress);
     event Initialized(uint8 version);
     event MigrateFailed(
-        address indexed operatorAddress, address indexed delegator, uint256 bnbAmount, StakeMigrationStatus status
+        address indexed operatorAddress, address indexed delegator, uint256 bnbAmount, StakeMigrationRespCode respCode
     );
     event MigrateSuccess(address indexed operatorAddress, address indexed delegator, uint256 shares, uint256 bnbAmount);
     event ParamChange(string key, bytes value);


### PR DESCRIPTION
### Description

This pr is to update `handleSynPackage` logic of `StakeHub`

### Changes

Notable changes:
* set `handleSynPackage` of `StakeHub` to revert when delegator in blacklist
