### PR TITLE
fix: sync govToken in `_doMigration`

### DIFF
--- a/abi/bscvalidatorset.abi
+++ b/abi/bscvalidatorset.abi
@@ -1539,6 +1539,19 @@
   },
   {
     "type": "event",
+    "name": "tmpValidatorSetUpdated",
+    "inputs": [
+      {
+        "name": "validatorsNum",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "unexpectedPackage",
     "inputs": [
       {

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -1051,6 +1051,8 @@ contract StakeHub is System, Initializable {
         emit Delegated(migrationPkg.operatorAddress, migrationPkg.delegator, shares, migrationPkg.amount);
         emit MigrateSuccess(migrationPkg.operatorAddress, migrationPkg.delegator, shares, migrationPkg.amount);
 
+        IGovToken(GOV_TOKEN_ADDR).sync(valInfo.creditContract, migrationPkg.delegator);
+
         return StakeMigrationRespCode.MIGRATE_SUCCESS;
     }
 

--- a/test/utils/interface/IBSCValidatorSet.sol
+++ b/test/utils/interface/IBSCValidatorSet.sol
@@ -14,6 +14,7 @@ interface BSCValidatorSet {
     event finalityRewardDeposit(address indexed validator, uint256 amount);
     event paramChange(string key, bytes value);
     event systemTransfer(uint256 amount);
+    event tmpValidatorSetUpdated(uint256 validatorsNum);
     event unexpectedPackage(uint8 channelId, bytes msgBytes);
     event validatorDeposit(address indexed validator, uint256 amount);
     event validatorEmptyJailed(address indexed validator);


### PR DESCRIPTION
### Description

This pr is to fix the issue of no syncing govToken in `_doMigration`

### Changes

Notable changes:
* sync govToken in `_doMigration`
