### PR TITLE
fix: add `isAutoUndelegate` for auto `DistributeUndelegatedSynPackage`

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -620,6 +620,7 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     address recipient;
     address validator;
     uint256 amount;
+    bool isAutoUndelegate;
     while (iter.hasNext()) {
       if (idx == 0) {
         recipient = address(uint160(iter.next().toAddress()));
@@ -628,6 +629,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
       } else if (idx == 2) {
         amount = uint256(iter.next().toUint());
         success = true;
+      } else if (idx == 3) {
+        isAutoUndelegate = iter.next().toBoolean();
       } else {
         break;
       }
@@ -642,6 +645,11 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
 
     pendingUndelegateTime[recipient][validator] = 0;
     undelegated[recipient] = undelegated[recipient].add(amount);
+
+    if (isAutoUndelegate) {
+      delegated[recipient] = delegated[recipient].sub(amount);
+      delegatedOfValidator[recipient][validator] = delegatedOfValidator[recipient][validator].sub(amount);
+    }
 
     emit undelegatedReceived(recipient, validator, amount);
     return (CODE_OK, new bytes(0));

--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -646,6 +646,8 @@ contract Staking is IStaking, System, IParamSubscriber, IApplication {
     pendingUndelegateTime[recipient][validator] = 0;
     undelegated[recipient] = undelegated[recipient].add(amount);
 
+    // this is to address the issue that the contract state will not being updated
+    // when the Beacon Chain system undelegate all the funds after second sunset upgrade
     if (isAutoUndelegate) {
       delegated[recipient] = delegated[recipient].sub(amount);
       delegatedOfValidator[recipient][validator] = delegatedOfValidator[recipient][validator].sub(amount);


### PR DESCRIPTION
### Description

This pr is to address the issue of the contract state not being updated correctly.

### Changes

Notable changes:
* add `isAutoUndelegate` for auto `DistributeUndelegatedSynPackage`
