### PR TITLE
feat: deprecate `transferOut` in `TokenHub`

### DIFF
--- a/abi/bscvalidatorset.abi
+++ b/abi/bscvalidatorset.abi
@@ -843,7 +843,7 @@
     "name": "getCurrentValidatorIndex",
     "inputs": [
       {
-        "name": "_validator",
+        "name": "validator",
         "type": "address",
         "internalType": "address"
       }

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -860,6 +860,9 @@ contract StakeHub is System, Initializable {
     }
 
     /**
+     * @param operatorAddress the operator address of the validator
+     * @param index the index of the day to query(timestamp / 1 days)
+     *
      * @return the validator's reward of the day
      */
     function getValidatorRewardRecord(address operatorAddress, uint256 index) external view returns (uint256) {
@@ -868,6 +871,9 @@ contract StakeHub is System, Initializable {
     }
 
     /**
+     * @param operatorAddress the operator address of the validator
+     * @param index the index of the day to query(timestamp / 1 days)
+     *
      * @return the validator's total pooled BNB of the day
      */
     function getValidatorTotalPooledBNBRecord(address operatorAddress, uint256 index) external view returns (uint256) {
@@ -877,6 +883,10 @@ contract StakeHub is System, Initializable {
 
     /**
      * @notice pagination query all validators' operator address and credit contract address
+     *
+     * @param offset the offset of the query
+     * @param limit the limit of the query
+     *
      * @return operatorAddrs operator addresses
      * @return creditAddrs credit contract addresses
      * @return totalLength total number of validators
@@ -902,6 +912,9 @@ contract StakeHub is System, Initializable {
 
     /**
      * @notice get the basic info of a validator
+     *
+     * @param operatorAddress the operator address of the validator
+     *
      * @return consensusAddress the consensus address of the validator
      * @return creditContract the credit contract address of the validator
      * @return createdTime the creation time of the validator
@@ -932,6 +945,8 @@ contract StakeHub is System, Initializable {
     }
 
     /**
+     * @param operatorAddress the operator address of the validator
+     *
      * @return the description of a validator
      */
     function getValidatorDescription(address operatorAddress)
@@ -944,6 +959,8 @@ contract StakeHub is System, Initializable {
     }
 
     /**
+     * @param operatorAddress the operator address of the validator
+     *
      * @return the commission of a validator
      */
     function getValidatorCommission(address operatorAddress)
@@ -957,7 +974,12 @@ contract StakeHub is System, Initializable {
 
     /**
      * @dev this function will be used by Parlia consensus engine.
+     *
      * @notice get the election info of a validator
+     *
+     * @param offset the offset of the query
+     * @param limit the limit of the query
+     *
      * @return consensusAddrs the consensus addresses of the validators
      * @return votingPowers the voting powers of the validators. The voting power will be 0 if the validator is jailed.
      * @return voteAddrs the vote addresses of the validators

--- a/contracts/TokenHub.sol
+++ b/contracts/TokenHub.sol
@@ -593,6 +593,7 @@ contract TokenHub is ITokenHub, System, IParamSubscriber, IApplication, ISystemR
 
   /**
    * @dev request a cross-chain transfer from BSC to BC
+   * @notice this function is deprecated after Feynman upgrade
    *
    * @param contractAddr The token contract which is transferred
    * @param recipient The destination address of the cross-chain transfer on BC.
@@ -600,46 +601,7 @@ contract TokenHub is ITokenHub, System, IParamSubscriber, IApplication, ISystemR
    * @param expireTime The expire time for the cross-chain transfer
    */
   function transferOut(address contractAddr, address recipient, uint256 amount, uint64 expireTime) external override onlyInit payable returns (bool) {
-    require(expireTime>=block.timestamp + 120, "expireTime must be two minutes later");
-    require(msg.value%TEN_DECIMALS==0, "invalid received BNB amount: precision loss in amount conversion");
-    bytes32 bep2TokenSymbol;
-    uint256 convertedAmount;
-    uint256 rewardForRelayer;
-    if (contractAddr==address(0x0)) {
-      require(msg.value>=amount.add(relayFee), "received BNB amount should be no less than the sum of transferOut BNB amount and minimum relayFee");
-      require(amount%TEN_DECIMALS==0, "invalid transfer amount: precision loss in amount conversion");
-      rewardForRelayer=msg.value.sub(amount);
-      convertedAmount = amount.div(TEN_DECIMALS); // native bnb decimals is 8 on BBC, while the native bnb decimals on BSC is 18
-      bep2TokenSymbol=BEP2_TOKEN_SYMBOL_FOR_BNB;
-    } else {
-      bep2TokenSymbol = contractAddrToBEP2Symbol[contractAddr];
-      require(bep2TokenSymbol!=bytes32(0x00), "the contract has not been bound to any bep2 token");
-      require(msg.value>=relayFee, "received BNB amount should be no less than the minimum relayFee");
-      rewardForRelayer=msg.value;
-      uint256 bep20TokenDecimals=bep20ContractDecimals[contractAddr];
-      require(bep20TokenDecimals<=BEP2_TOKEN_DECIMALS || (bep20TokenDecimals>BEP2_TOKEN_DECIMALS && amount.mod(10**(bep20TokenDecimals-BEP2_TOKEN_DECIMALS))==0), "invalid transfer amount: precision loss in amount conversion");
-      convertedAmount = convertToBep2Amount(amount, bep20TokenDecimals);// convert to bep2 amount
-      if (isMiniBEP2Token(bep2TokenSymbol)) {
-        require(convertedAmount >= 1e8 , "For miniToken, the transfer amount must not be less than 1");
-      }
-      require(bep20TokenDecimals>=BEP2_TOKEN_DECIMALS || (bep20TokenDecimals<BEP2_TOKEN_DECIMALS && convertedAmount>amount), "amount is too large, uint256 overflow");
-      require(convertedAmount<=MAX_BEP2_TOTAL_SUPPLY, "amount is too large, exceed maximum bep2 token amount");
-      require(IBEP20(contractAddr).transferFrom(msg.sender, address(this), amount));
-    }
-    TransferOutSynPackage memory transOutSynPkg = TransferOutSynPackage({
-      bep2TokenSymbol: bep2TokenSymbol,
-      contractAddr: contractAddr,
-      amounts: new uint256[](1),
-      recipients: new address[](1),
-      refundAddrs: new address[](1),
-      expireTime: expireTime
-    });
-    transOutSynPkg.amounts[0]=convertedAmount;
-    transOutSynPkg.recipients[0]=recipient;
-    transOutSynPkg.refundAddrs[0]=msg.sender;
-    ICrossChain(CROSS_CHAIN_CONTRACT_ADDR).sendSynPackage(TRANSFER_OUT_CHANNELID, encodeTransferOutSynPackage(transOutSynPkg), rewardForRelayer.div(TEN_DECIMALS));
-    emit transferOutSuccess(contractAddr, msg.sender, amount, rewardForRelayer);
-    return true;
+    return false;
   }
 
   /**

--- a/contracts/TokenHub.sol
+++ b/contracts/TokenHub.sol
@@ -601,7 +601,7 @@ contract TokenHub is ITokenHub, System, IParamSubscriber, IApplication, ISystemR
    * @param expireTime The expire time for the cross-chain transfer
    */
   function transferOut(address contractAddr, address recipient, uint256 amount, uint64 expireTime) external override onlyInit payable returns (bool) {
-    return false;
+    revert("deprecated");
   }
 
   /**

--- a/test/TokenHub.t.sol
+++ b/test/TokenHub.t.sol
@@ -442,81 +442,81 @@ contract TokenHubTest is Deployer {
         assertEq(amount, 0, "wrong locked amount after cancelTransfer");
     }
 
-    function testTransferOut() public {
-        bytes memory pack = buildBindPackage(uint8(0), bytes32("ABC-9C7"), address(abcToken), 1e8, 99e6, uint8(18));
-        vm.prank(address(crossChain));
-        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
-
-        abcToken.approve(address(tokenManager), 1e8 * 1e18);
-        tokenManager.approveBind{ value: 1e16 }(address(abcToken), "ABC-9C7");
-
-        uint64 expireTime = uint64(block.timestamp + 150);
-        address recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
-        uint256 amount = 1e8;
-        uint256 relayerFee = 1e14;
-
-        vm.expectRevert(bytes("received BNB amount should be no less than the minimum relayFee"));
-        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
-
-        relayerFee = 1e16;
-        vm.expectRevert(bytes("invalid transfer amount: precision loss in amount conversion"));
-        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
-
-        amount = 1e18;
-        vm.expectRevert(bytes("invalid received BNB amount: precision loss in amount conversion"));
-        tokenHub.transferOut{ value: relayerFee + 1 }(address(abcToken), recipient, amount, expireTime);
-
-        vm.expectRevert(bytes("BEP20: transfer amount exceeds allowance"));
-        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
-
-        vm.expectRevert(bytes("the contract has not been bound to any bep2 token"));
-        tokenHub.transferOut{ value: relayerFee }(address(defToken), recipient, amount, expireTime);
-
-        vm.expectRevert(bytes("received BNB amount should be no less than the minimum relayFee"));
-        tokenHub.transferOut(address(abcToken), recipient, amount, expireTime);
-
-        uint256 balance = abcToken.balanceOf(address(this));
-        abcToken.approve(address(tokenHub), amount);
-        vm.expectEmit(true, false, false, true, address(tokenHub));
-        emit transferOutSuccess(address(abcToken), address(this), amount, relayerFee);
-        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
-        assertEq(abcToken.balanceOf(address(this)), balance - amount, "wrong balance");
-
-        // refund
-        uint256[] memory amounts = new uint256[](1);
-        address[] memory refundAddrs = new address[](1);
-        amounts[0] = amount;
-        refundAddrs[0] = address(this);
-        bytes memory package = buildRefundPackage(address(abcToken), amounts, refundAddrs, uint32(1));
-
-        vm.prank(address(crossChain));
-        vm.expectEmit(true, false, false, true, address(tokenHub));
-        emit refundSuccess(address(abcToken), address(this), amount, 1);
-        tokenHub.handleAckPackage(TRANSFER_OUT_CHANNELID, package);
-        assertEq(abcToken.balanceOf(address(this)), balance, "wrong balance");
-
-        // Fail ack refund
-        uint256 length = 5;
-        uint256[] memory balances = new uint256[](length);
-        address[] memory recipients = new address[](length);
-        amounts = new uint256[](length);
-        refundAddrs = new address[](length);
-        for (uint256 i; i < length; ++i) {
-            amounts[i] = (i + 1) * 1e6;
-            recipient = _getNextUserAddress();
-            balances[i] = abcToken.balanceOf(recipient);
-            recipients[i] = recipient;
-            refundAddrs[i] = recipient;
-        }
-
-        package =
-            buildBatchTransferOutFailAckPackage(bytes32("ABC-9C7"), address(abcToken), amounts, recipients, refundAddrs);
-        vm.prank(address(crossChain));
-        tokenHub.handleFailAckPackage(TRANSFER_OUT_CHANNELID, package);
-        for (uint256 i; i < length; ++i) {
-            assertEq(abcToken.balanceOf(recipients[i]) - balances[i], amounts[i] * 1e10, "wrong balance");
-        }
-    }
+    //    function testTransferOut() public {
+    //        bytes memory pack = buildBindPackage(uint8(0), bytes32("ABC-9C7"), address(abcToken), 1e8, 99e6, uint8(18));
+    //        vm.prank(address(crossChain));
+    //        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
+    //
+    //        abcToken.approve(address(tokenManager), 1e8 * 1e18);
+    //        tokenManager.approveBind{ value: 1e16 }(address(abcToken), "ABC-9C7");
+    //
+    //        uint64 expireTime = uint64(block.timestamp + 150);
+    //        address recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
+    //        uint256 amount = 1e8;
+    //        uint256 relayerFee = 1e14;
+    //
+    //        vm.expectRevert(bytes("received BNB amount should be no less than the minimum relayFee"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
+    //
+    //        relayerFee = 1e16;
+    //        vm.expectRevert(bytes("invalid transfer amount: precision loss in amount conversion"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
+    //
+    //        amount = 1e18;
+    //        vm.expectRevert(bytes("invalid received BNB amount: precision loss in amount conversion"));
+    //        tokenHub.transferOut{ value: relayerFee + 1 }(address(abcToken), recipient, amount, expireTime);
+    //
+    //        vm.expectRevert(bytes("BEP20: transfer amount exceeds allowance"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
+    //
+    //        vm.expectRevert(bytes("the contract has not been bound to any bep2 token"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(defToken), recipient, amount, expireTime);
+    //
+    //        vm.expectRevert(bytes("received BNB amount should be no less than the minimum relayFee"));
+    //        tokenHub.transferOut(address(abcToken), recipient, amount, expireTime);
+    //
+    //        uint256 balance = abcToken.balanceOf(address(this));
+    //        abcToken.approve(address(tokenHub), amount);
+    //        vm.expectEmit(true, false, false, true, address(tokenHub));
+    //        emit transferOutSuccess(address(abcToken), address(this), amount, relayerFee);
+    //        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
+    //        assertEq(abcToken.balanceOf(address(this)), balance - amount, "wrong balance");
+    //
+    //        // refund
+    //        uint256[] memory amounts = new uint256[](1);
+    //        address[] memory refundAddrs = new address[](1);
+    //        amounts[0] = amount;
+    //        refundAddrs[0] = address(this);
+    //        bytes memory package = buildRefundPackage(address(abcToken), amounts, refundAddrs, uint32(1));
+    //
+    //        vm.prank(address(crossChain));
+    //        vm.expectEmit(true, false, false, true, address(tokenHub));
+    //        emit refundSuccess(address(abcToken), address(this), amount, 1);
+    //        tokenHub.handleAckPackage(TRANSFER_OUT_CHANNELID, package);
+    //        assertEq(abcToken.balanceOf(address(this)), balance, "wrong balance");
+    //
+    //        // Fail ack refund
+    //        uint256 length = 5;
+    //        uint256[] memory balances = new uint256[](length);
+    //        address[] memory recipients = new address[](length);
+    //        amounts = new uint256[](length);
+    //        refundAddrs = new address[](length);
+    //        for (uint256 i; i < length; ++i) {
+    //            amounts[i] = (i + 1) * 1e6;
+    //            recipient = _getNextUserAddress();
+    //            balances[i] = abcToken.balanceOf(recipient);
+    //            recipients[i] = recipient;
+    //            refundAddrs[i] = recipient;
+    //        }
+    //
+    //        package =
+    //            buildBatchTransferOutFailAckPackage(bytes32("ABC-9C7"), address(abcToken), amounts, recipients, refundAddrs);
+    //        vm.prank(address(crossChain));
+    //        tokenHub.handleFailAckPackage(TRANSFER_OUT_CHANNELID, package);
+    //        for (uint256 i; i < length; ++i) {
+    //            assertEq(abcToken.balanceOf(recipients[i]) - balances[i], amounts[i] * 1e10, "wrong balance");
+    //        }
+    //    }
 
     function testBatchTransferOutBNB() public {
         uint64 expireTime = uint64(block.timestamp + 150);
@@ -540,126 +540,126 @@ contract TokenHubTest is Deployer {
         tokenHub.batchTransferOutBNB{ value: 5e16 }(recipients, amounts, refundAddrs, expireTime);
     }
 
-    function testOverflow() public {
-        uint64 expireTime = uint64(block.timestamp + 150);
-        address recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
-        uint256 amount = 115792089237316195423570985008687907853269984665640564039457584007903129639936;
-        uint256 relayerFee = 1e16;
+    //    function testOverflow() public {
+    //        uint64 expireTime = uint64(block.timestamp + 150);
+    //        address recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
+    //        uint256 amount = 115792089237316195423570985008687907853269984665640564039457584007903129639936;
+    //        uint256 relayerFee = 1e16;
+    //
+    //        vm.expectRevert(bytes("SafeMath: addition overflow"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(0), recipient, amount, expireTime);
+    //
+    //        // batch transfer out
+    //        address[] memory recipients = new address[](2);
+    //        address[] memory refundAddrs = new address[](2);
+    //        uint256[] memory amounts = new uint256[](2);
+    //        recipient = _getNextUserAddress();
+    //        for (uint256 i; i < 2; ++i) {
+    //            recipients[i] = recipient;
+    //            refundAddrs[i] = _getNextUserAddress();
+    //        }
+    //        amounts[0] = 100000000000000000000000000000000000000000000000000000000000000000000000000000;
+    //        amounts[1] = 15792089237316195423570985008687907853269984665640564039457584007910000000000;
+    //
+    //        vm.expectRevert(bytes("SafeMath: addition overflow"));
+    //        tokenHub.batchTransferOutBNB{ value: 2e16 }(recipients, amounts, refundAddrs, expireTime);
+    //    }
 
-        vm.expectRevert(bytes("SafeMath: addition overflow"));
-        tokenHub.transferOut{ value: relayerFee }(address(0), recipient, amount, expireTime);
+    //    function testUnbind() public {
+    //        // Bind first
+    //        bytes memory pack = buildBindPackage(uint8(0), bytes32("ABC-9C7"), address(abcToken), 1e8, 99e6, uint8(18));
+    //        vm.prank(address(crossChain));
+    //        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
+    //
+    //        abcToken.approve(address(tokenManager), 1e8 * 1e18);
+    //        tokenManager.approveBind{ value: 1e16 }(address(abcToken), "ABC-9C7");
+    //
+    //        // Unbind
+    //        pack = buildBindPackage(uint8(1), bytes32("ABC-9C7"), address(abcToken), 0, 0, uint8(0));
+    //        vm.prank(address(crossChain));
+    //        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
+    //
+    //        assertEq(tokenHub.getBoundBep2Symbol(address(abcToken)), "", "wrong symbol");
+    //        assertEq(tokenHub.getBoundContract("ABC-9C7"), address(0x0), "wrong token contract address");
+    //
+    //        // TransferIn failed
+    //        address recipient = _getNextUserAddress();
+    //        address refundAddr = _getNextUserAddress();
+    //        assertEq(abcToken.balanceOf(recipient), 0);
+    //        pack = buildTransferInPackage(bytes32("ABC-9C7"), address(abcToken), 115e17, recipient, refundAddr);
+    //        vm.prank(address(crossChain));
+    //        tokenHub.handleSynPackage(TRANSFER_IN_CHANNELID, pack);
+    //        assertEq(abcToken.balanceOf(recipient), 0, "wrong balance");
+    //
+    //        // TransferOut refund
+    //        recipient = _getNextUserAddress();
+    //        uint256 amount = 1e18;
+    //        uint256[] memory amounts = new uint256[](1);
+    //        address[] memory refundAddrs = new address[](1);
+    //        amounts[0] = amount;
+    //        refundAddrs[0] = recipient;
+    //        bytes memory package = buildRefundPackage(address(abcToken), amounts, refundAddrs, uint32(1));
+    //        abcToken.transfer(address(tokenHub), amount);
+    //
+    //        vm.prank(address(crossChain));
+    //        vm.expectEmit(true, false, false, true, address(tokenHub));
+    //        emit refundSuccess(address(abcToken), recipient, amount, 1);
+    //        tokenHub.handleAckPackage(TRANSFER_OUT_CHANNELID, package);
+    //        assertEq(abcToken.balanceOf(recipient), amount, "wrong balance");
+    //
+    //        // TransferOut failed
+    //        uint64 expireTime = uint64(block.timestamp + 150);
+    //        uint256 relayerFee = 1e14;
+    //        recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
+    //        amount = 1e8;
+    //
+    //        abcToken.approve(address(tokenHub), amount);
+    //        vm.expectRevert(bytes("the contract has not been bound to any bep2 token"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
+    //    }
 
-        // batch transfer out
-        address[] memory recipients = new address[](2);
-        address[] memory refundAddrs = new address[](2);
-        uint256[] memory amounts = new uint256[](2);
-        recipient = _getNextUserAddress();
-        for (uint256 i; i < 2; ++i) {
-            recipients[i] = recipient;
-            refundAddrs[i] = _getNextUserAddress();
-        }
-        amounts[0] = 100000000000000000000000000000000000000000000000000000000000000000000000000000;
-        amounts[1] = 15792089237316195423570985008687907853269984665640564039457584007910000000000;
-
-        vm.expectRevert(bytes("SafeMath: addition overflow"));
-        tokenHub.batchTransferOutBNB{ value: 2e16 }(recipients, amounts, refundAddrs, expireTime);
-    }
-
-    function testUnbind() public {
-        // Bind first
-        bytes memory pack = buildBindPackage(uint8(0), bytes32("ABC-9C7"), address(abcToken), 1e8, 99e6, uint8(18));
-        vm.prank(address(crossChain));
-        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
-
-        abcToken.approve(address(tokenManager), 1e8 * 1e18);
-        tokenManager.approveBind{ value: 1e16 }(address(abcToken), "ABC-9C7");
-
-        // Unbind
-        pack = buildBindPackage(uint8(1), bytes32("ABC-9C7"), address(abcToken), 0, 0, uint8(0));
-        vm.prank(address(crossChain));
-        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
-
-        assertEq(tokenHub.getBoundBep2Symbol(address(abcToken)), "", "wrong symbol");
-        assertEq(tokenHub.getBoundContract("ABC-9C7"), address(0x0), "wrong token contract address");
-
-        // TransferIn failed
-        address recipient = _getNextUserAddress();
-        address refundAddr = _getNextUserAddress();
-        assertEq(abcToken.balanceOf(recipient), 0);
-        pack = buildTransferInPackage(bytes32("ABC-9C7"), address(abcToken), 115e17, recipient, refundAddr);
-        vm.prank(address(crossChain));
-        tokenHub.handleSynPackage(TRANSFER_IN_CHANNELID, pack);
-        assertEq(abcToken.balanceOf(recipient), 0, "wrong balance");
-
-        // TransferOut refund
-        recipient = _getNextUserAddress();
-        uint256 amount = 1e18;
-        uint256[] memory amounts = new uint256[](1);
-        address[] memory refundAddrs = new address[](1);
-        amounts[0] = amount;
-        refundAddrs[0] = recipient;
-        bytes memory package = buildRefundPackage(address(abcToken), amounts, refundAddrs, uint32(1));
-        abcToken.transfer(address(tokenHub), amount);
-
-        vm.prank(address(crossChain));
-        vm.expectEmit(true, false, false, true, address(tokenHub));
-        emit refundSuccess(address(abcToken), recipient, amount, 1);
-        tokenHub.handleAckPackage(TRANSFER_OUT_CHANNELID, package);
-        assertEq(abcToken.balanceOf(recipient), amount, "wrong balance");
-
-        // TransferOut failed
-        uint64 expireTime = uint64(block.timestamp + 150);
-        uint256 relayerFee = 1e14;
-        recipient = 0xd719dDfA57bb1489A08DF33BDE4D5BA0A9998C60;
-        amount = 1e8;
-
-        abcToken.approve(address(tokenHub), amount);
-        vm.expectRevert(bytes("the contract has not been bound to any bep2 token"));
-        tokenHub.transferOut{ value: relayerFee }(address(abcToken), recipient, amount, expireTime);
-    }
-
-    function testMiniToken() public {
-        // Bind
-        bytes memory pack = buildBindPackage(uint8(0), bytes32("XYZ-9C7M"), address(miniToken), 1e4, 5e3, uint8(18));
-        vm.prank(address(crossChain));
-        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
-
-        miniToken.approve(address(tokenManager), 5e3 * 1e18);
-        vm.expectEmit(true, false, false, true, address(tokenManager));
-        emit bindSuccess(address(miniToken), "XYZ-9C7M", 1e4 * 1e18, 5e3 * 1e18);
-        tokenManager.approveBind{ value: 1e16 }(address(miniToken), "XYZ-9C7M");
-
-        assertEq(tokenHub.getBoundBep2Symbol(address(miniToken)), "XYZ-9C7M", "wrong bep2 symbol");
-        assertEq(tokenHub.getBoundContract("XYZ-9C7M"), address(miniToken), "wrong token contract address");
-
-        // TransferIn
-        address recipient = _getNextUserAddress();
-        address refundAddr = _getNextUserAddress();
-        assertEq(miniToken.balanceOf(recipient), 0);
-        pack = buildTransferInPackage(bytes32("XYZ-9C7M"), address(miniToken), 1e18, recipient, refundAddr);
-        vm.prank(address(crossChain));
-        tokenHub.handleSynPackage(TRANSFER_IN_CHANNELID, pack);
-        assertEq(miniToken.balanceOf(recipient), 1e18, "wrong balance");
-
-        // TransferOut
-        uint64 expireTime = uint64(block.timestamp + 150);
-        uint256 amount = 1e18;
-        uint256 relayerFee = 1e16;
-        recipient = _getNextUserAddress();
-
-        miniToken.approve(address(tokenHub), amount);
-        vm.expectEmit(true, false, false, true, address(tokenHub));
-        emit transferOutSuccess(address(miniToken), address(this), 1e18, 1e16);
-        tokenHub.transferOut{ value: relayerFee }(address(miniToken), recipient, amount, expireTime);
-
-        // TransferOut failed
-        amount = 5e17;
-        recipient = _getNextUserAddress();
-
-        miniToken.approve(address(tokenHub), amount);
-        vm.expectRevert(bytes("For miniToken, the transfer amount must not be less than 1"));
-        tokenHub.transferOut{ value: relayerFee }(address(miniToken), recipient, amount, expireTime);
-    }
+    //    function testMiniToken() public {
+    //        // Bind
+    //        bytes memory pack = buildBindPackage(uint8(0), bytes32("XYZ-9C7M"), address(miniToken), 1e4, 5e3, uint8(18));
+    //        vm.prank(address(crossChain));
+    //        tokenManager.handleSynPackage(BIND_CHANNELID, pack);
+    //
+    //        miniToken.approve(address(tokenManager), 5e3 * 1e18);
+    //        vm.expectEmit(true, false, false, true, address(tokenManager));
+    //        emit bindSuccess(address(miniToken), "XYZ-9C7M", 1e4 * 1e18, 5e3 * 1e18);
+    //        tokenManager.approveBind{ value: 1e16 }(address(miniToken), "XYZ-9C7M");
+    //
+    //        assertEq(tokenHub.getBoundBep2Symbol(address(miniToken)), "XYZ-9C7M", "wrong bep2 symbol");
+    //        assertEq(tokenHub.getBoundContract("XYZ-9C7M"), address(miniToken), "wrong token contract address");
+    //
+    //        // TransferIn
+    //        address recipient = _getNextUserAddress();
+    //        address refundAddr = _getNextUserAddress();
+    //        assertEq(miniToken.balanceOf(recipient), 0);
+    //        pack = buildTransferInPackage(bytes32("XYZ-9C7M"), address(miniToken), 1e18, recipient, refundAddr);
+    //        vm.prank(address(crossChain));
+    //        tokenHub.handleSynPackage(TRANSFER_IN_CHANNELID, pack);
+    //        assertEq(miniToken.balanceOf(recipient), 1e18, "wrong balance");
+    //
+    //        // TransferOut
+    //        uint64 expireTime = uint64(block.timestamp + 150);
+    //        uint256 amount = 1e18;
+    //        uint256 relayerFee = 1e16;
+    //        recipient = _getNextUserAddress();
+    //
+    //        miniToken.approve(address(tokenHub), amount);
+    //        vm.expectEmit(true, false, false, true, address(tokenHub));
+    //        emit transferOutSuccess(address(miniToken), address(this), 1e18, 1e16);
+    //        tokenHub.transferOut{ value: relayerFee }(address(miniToken), recipient, amount, expireTime);
+    //
+    //        // TransferOut failed
+    //        amount = 5e17;
+    //        recipient = _getNextUserAddress();
+    //
+    //        miniToken.approve(address(tokenHub), amount);
+    //        vm.expectRevert(bytes("For miniToken, the transfer amount must not be less than 1"));
+    //        tokenHub.transferOut{ value: relayerFee }(address(miniToken), recipient, amount, expireTime);
+    //    }
 
     function testMirrorFailed() public {
         uint256 mirrorFee = 1e20;

--- a/test/utils/interface/IBSCValidatorSet.sol
+++ b/test/utils/interface/IBSCValidatorSet.sol
@@ -98,7 +98,7 @@ interface BSCValidatorSet {
     function exitMaintenance() external;
     function expireTimeSecondGap() external view returns (uint256);
     function felony(address validator) external;
-    function getCurrentValidatorIndex(address _validator) external view returns (uint256);
+    function getCurrentValidatorIndex(address validator) external view returns (uint256);
     function getIncoming(address validator) external view returns (uint256);
     function getLivingValidators() external view returns (address[] memory, bytes[] memory);
     function getMiningValidators() external view returns (address[] memory, bytes[] memory);


### PR DESCRIPTION
### Description

This pr is to forbid the `transferOut` method in `TokenHub` after Feynman upgrade

### Changes

Notable changes: 
* deprecate `transferOut` in `TokenHub`
* optimize some annotations and view functions in `BSCValidatorSet`
