### PR TITLE
feat: add `whenNotPaused` to slash functions

### DIFF
--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -685,7 +685,7 @@ contract StakeHub is System, Initializable {
     /**
      * @dev Malicious vote slash. Only the `SlashIndicator` contract can call this function.
      */
-    function maliciousVoteSlash(bytes calldata voteAddress) external onlySlash {
+    function maliciousVoteSlash(bytes calldata voteAddress) external onlySlash whenNotPaused {
         address operatorAddress = voteToOperator[voteAddress];
         if (!_validatorSet.contains(operatorAddress)) revert ValidatorNotExist(); // should never happen
         Validator storage valInfo = _validators[operatorAddress];
@@ -715,7 +715,7 @@ contract StakeHub is System, Initializable {
     /**
      * @dev Double sign slash. Only the `SlashIndicator` contract can call this function.
      */
-    function doubleSignSlash(address consensusAddress) external onlySlash {
+    function doubleSignSlash(address consensusAddress) external onlySlash whenNotPaused {
         address operatorAddress = consensusToOperator[consensusAddress];
         if (!_validatorSet.contains(operatorAddress)) revert ValidatorNotExist(); // should never happen
         Validator storage valInfo = _validators[operatorAddress];


### PR DESCRIPTION
### Description

This pr is to add `whenNotPaused` to slash functions in `StakeHub`

### Changes

Notable changes: 
* add `whenNotPaused` to slash functions

