### PR TITLE
test: add failed cases to TokenRecoverPortal unit-test

### DIFF
--- a/contracts/BC_fusion/TokenRecoverPortal.sol
+++ b/contracts/BC_fusion/TokenRecoverPortal.sol
@@ -71,7 +71,7 @@ contract TokenRecoverPortal is System, Initializable, ReentrancyGuardUpgradeable
 
     /*----------------- events -----------------*/
     // This event is triggered whenever a call to #recover succeeds.
-    event TokenRecoverRequested(bytes32 tokenSymbol, address account, uint256 amount);
+    event TokenRecoverRequested(bytes ownerAddress, bytes32 tokenSymbol, address account, uint256 amount);
 
     /*----------------- init -----------------*/
     function initialize() external initializer onlyCoinbase onlyZeroGasPrice {
@@ -132,7 +132,7 @@ contract TokenRecoverPortal is System, Initializable, ReentrancyGuardUpgradeable
         // recover the token from TokenHub contract. it will be unlocked after 7 days.
         ITokenHub(TOKEN_HUB_ADDR).recoverBCAsset(tokenSymbol, msg.sender, amount);
 
-        emit TokenRecoverRequested(tokenSymbol, msg.sender, amount);
+        emit TokenRecoverRequested(ownerAddr, tokenSymbol, msg.sender, amount);
     }
 
     /**

--- a/test/TokenRecoverPortal.t.sol
+++ b/test/TokenRecoverPortal.t.sol
@@ -44,23 +44,36 @@ contract TokenRecoverPortalTest is Deployer {
         vm.prank(block.coinbase);
         vm.txGasPrice(0);
         tokenRecoverPortal.initialize();
+    }
 
+    function setUpContractParams(address newApprovalAddress, bytes memory newMerkleRoot, address newProtector) internal {
         // set the approvalAddress, merkleRoot and tokenRecoverPortalProtector
         bytes memory key = "approvalAddress";
-        bytes memory value = abi.encodePacked(approvalAddress);
+        bytes memory value = abi.encodePacked(newApprovalAddress);
         _updateParamByGovHub(key, value, address(tokenRecoverPortal));
 
         bytes memory key2 = "merkleRoot";
-        bytes memory value2 = merkleRoot;
+        bytes memory value2 = newMerkleRoot;
         _updateParamByGovHub(key2, value2, address(tokenRecoverPortal));
 
         bytes memory key3 = "tokenRecoverPortalProtector";
-        bytes memory value3 = abi.encodePacked(protector);
+        bytes memory value3 = abi.encodePacked(newProtector);
         _updateParamByGovHub(key3, value3, address(tokenRecoverPortal));
     }
 
-    function testRecover() public {
-        vm.prank(mockUser);
+    function setUpCorrectContractParams() public {
+        setUpContractParams(approvalAddress, merkleRoot, protector);
+    }
+
+    function setUpContractParamsWithWrongApprovelAddress() public {
+        setUpContractParams(address(0x561319e67357fa3d2b51E58d011a80EB6268A0f5), hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554", protector);
+    }
+
+    function setUpContractParamsWithWrongMerkleRoot() public {
+        setUpContractParams(approvalAddress, hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554", protector);
+    }
+
+    function recoverParams() internal view returns (bytes32, uint256, bytes memory, bytes memory, bytes memory, bytes32[] memory) {
         bytes32 tokenSymbol = testTokenSymbol;
         uint256 amount = 14188000000;
         bytes memory ownerPubKey = hex"036d5d41cd7da2e96d39bcbd0390bfed461a86382f7a2923436ff16c65cabc7719";
@@ -84,6 +97,181 @@ contract TokenRecoverPortalTest is Deployer {
         merkleProof[14] = hex"e096d4b3669b1c7cd8fcff26b2b00029c09c0f38a34ae632b022622fb46ad69a";
         merkleProof[15] = hex"05e63b558cba63f5add60201151f96ff8f5370d2b8280a96b4fa8fd2d519ab9f";
         merkleProof[16] = hex"a2d456e52facaa953bfbc79a5a6ed7647dda59872b9b35c20183887eeb4640eb";
+
+        return (tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongApprovalAddress() public {
+        setUpContractParamsWithWrongApprovelAddress();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongMerkleRoot() public {
+        setUpContractParamsWithWrongMerkleRoot();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongRecipient() public {
+        setUpCorrectContractParams();
+        vm.prank(address(0x561319e67357fa3d2b51E58d011a80EB6268A0f5));
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongTokenSymbol() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        tokenSymbol = hex"4241110000000000000000000000000000000000000000000000000000000000";
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongAmount() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        amount = 188000001;
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongOwnerPubKey() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+
+        vm.expectRevert();
+        vm.mockCall(address(0x69), "", hex"1111100f29effb427fb76a185b4ac73ea09a534b");
+        ownerPubKey = hex"11111111cd7da2e96d39bcbd0390bfed461a86382f7a2923436ff16c65cabc7720";
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongOwnerSignature() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        ownerSignature = hex"111111117f2b002b4746025f7e803a43e57a397ea66f3939d05302eb7851bbbc0773cda87aae0fbb1e2a29367b606209ed47dc5cba6d1a83f6b79cb70e56efdb";
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongApprovalSignature() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        approvalSignature = hex"1111111180beb068d82413cac31c1df0540dc6a61eddec9f31b94419e60b6c586e5342552f4c8034a00c876d640abea8c5ba9c4d72145d0e562fedd09fe1e00a02";
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecoverFaildWithWrongMerkleProof() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
+
+        merkleProof[13] = hex"1111111190245e6a9e1e969ae3f6f0315ea073606fd6fabe9f3d7514c84fee98";
+        vm.expectRevert();
+        // failed to recover the token
+        tokenRecoverPortal.recover(
+            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+    }
+
+    function testRecover() public {
+        setUpCorrectContractParams();
+        vm.prank(mockUser);
+        
+        (bytes32 tokenSymbol,
+         uint256 amount,
+         bytes memory ownerPubKey, 
+         bytes memory ownerSignature, 
+         bytes memory approvalSignature,
+         bytes32[] memory merkleProof) = recoverParams();
 
         // recover the token
         tokenRecoverPortal.recover(


### PR DESCRIPTION
### Description
add failed cases to the TokenRecoverPortal unit-test

### Changes

Notable changes:
* add more test cases to TokenRecoverPortal
