### PR TITLE
fix: improve the code readablity

### DIFF
--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -1122,13 +1122,6 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
     address validator;
     bool isFelony;
 
-    // count the number of felony validators before forcing maintaining validators exit
-    for (uint i; i<_validatorSet.length; ++i) {
-      if (_validatorSet[i].jailed) {
-        ++numOfFelony;
-      }
-    }
-
     // 1. validators exit maintenance
     uint256 i;
     // caution: it must calculate workingValidatorCount before _exitMaintenance loop
@@ -1154,12 +1147,16 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
       // record the jailed validator in validatorSet
       for (uint k; k<_validatorSet.length; ++k) {
         if (_validatorSet[k].consensusAddress == validator) {
-          if (!_validatorSet[k].jailed) {
-            _validatorSet[k].jailed = true;
-            ++numOfFelony;
-          }
+          _validatorSet[k].jailed = true;
           break;
         }
+      }
+    }
+
+    // count the number of felony validators before forcing maintaining validators exit
+    for (uint i; i<_validatorSet.length; ++i) {
+      if (_validatorSet[i].jailed) {
+        ++numOfFelony;
       }
     }
 

--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -1153,7 +1153,7 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
       }
     }
 
-    // count the number of felony validators before forcing maintaining validators exit
+    // count the number of felony validators
     for (uint i; i<_validatorSet.length; ++i) {
       if (_validatorSet[i].jailed) {
         ++numOfFelony;


### PR DESCRIPTION
The current implementation is not easy to understand because `numOfFelony` will increase in two different place.

After change, we count the number of felony validators just before we use it to generate the slice.