### PR TITLE
fix: add check in `_forceMaintainingValidatorsExit`

### DIFF
--- a/abi/stakehub.abi
+++ b/abi/stakehub.abi
@@ -459,24 +459,9 @@
     ],
     "outputs": [
       {
-        "name": "consensusAddress",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
-        "name": "creditContract",
-        "type": "address",
-        "internalType": "address"
-      },
-      {
         "name": "createdTime",
         "type": "uint256",
         "internalType": "uint256"
-      },
-      {
-        "name": "voteAddress",
-        "type": "bytes",
-        "internalType": "bytes"
       },
       {
         "name": "jailed",
@@ -523,6 +508,44 @@
             "internalType": "uint64"
           }
         ]
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getValidatorConsensusAddress",
+    "inputs": [
+      {
+        "name": "operatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "consensusAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getValidatorCreditContract",
+    "inputs": [
+      {
+        "name": "operatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "creditContract",
+        "type": "address",
+        "internalType": "address"
       }
     ],
     "stateMutability": "view"
@@ -651,6 +674,25 @@
         "name": "",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "getValidatorVoteAddress",
+    "inputs": [
+      {
+        "name": "operatorAddress",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "voteAddress",
+        "type": "bytes",
+        "internalType": "bytes"
       }
     ],
     "stateMutability": "view"

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -872,35 +872,57 @@ contract StakeHub is System, Initializable, Protectable {
     }
 
     /**
-     * @notice get the basic info of a validator
+     * @notice get the consensus address of a validator
      *
      * @param operatorAddress the operator address of the validator
      *
      * @return consensusAddress the consensus address of the validator
+     */
+    function getValidatorConsensusAddress(address operatorAddress) external view returns (address consensusAddress) {
+        Validator memory valInfo = _validators[operatorAddress];
+        consensusAddress = valInfo.consensusAddress;
+    }
+
+    /**
+     * @notice get the credit contract address of a validator
+     *
+     * @param operatorAddress the operator address of the validator
+     *
      * @return creditContract the credit contract address of the validator
-     * @return createdTime the creation time of the validator
+     */
+    function getValidatorCreditContract(address operatorAddress) external view returns (address creditContract) {
+        Validator memory valInfo = _validators[operatorAddress];
+        creditContract = valInfo.creditContract;
+    }
+
+    /**
+     * @notice get the vote address of a validator
+     *
+     * @param operatorAddress the operator address of the validator
+     *
      * @return voteAddress the vote address of the validator
+     */
+    function getValidatorVoteAddress(address operatorAddress) external view returns (bytes memory voteAddress) {
+        Validator memory valInfo = _validators[operatorAddress];
+        voteAddress = valInfo.voteAddress;
+    }
+
+    /**
+     * @notice get the basic info of a validator
+     *
+     * @param operatorAddress the operator address of the validator
+     *
+     * @return createdTime the creation time of the validator
      * @return jailed whether the validator is jailed
      * @return jailUntil the jail time of the validator
      */
     function getValidatorBasicInfo(address operatorAddress)
         external
         view
-        validatorExist(operatorAddress)
-        returns (
-            address consensusAddress,
-            address creditContract,
-            uint256 createdTime,
-            bytes memory voteAddress,
-            bool jailed,
-            uint256 jailUntil
-        )
+        returns (uint256 createdTime, bool jailed, uint256 jailUntil)
     {
         Validator memory valInfo = _validators[operatorAddress];
-        consensusAddress = valInfo.consensusAddress;
-        creditContract = valInfo.creditContract;
         createdTime = valInfo.createdTime;
-        voteAddress = valInfo.voteAddress;
         jailed = valInfo.jailed;
         jailUntil = valInfo.jailUntil;
     }

--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -1144,6 +1144,12 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
         continue;
       }
 
+      // get the latest consensus address
+      address operatorAddress = IStakeHub(STAKE_HUB_ADDR).consensusToOperator(validator);
+      if (operatorAddress != address(0)) {
+        validator = IStakeHub(STAKE_HUB_ADDR).getValidatorConsensusAddress(operatorAddress);
+      }
+
       // record the jailed validator in validatorSet
       for (uint k; k<_validatorSet.length; ++k) {
         if (_validatorSet[k].consensusAddress == validator) {

--- a/contracts/BSCValidatorSet.sol
+++ b/contracts/BSCValidatorSet.sol
@@ -1145,14 +1145,15 @@ contract BSCValidatorSet is IBSCValidatorSet, System, IParamSubscriber, IApplica
       }
 
       // get the latest consensus address
+      address latestConsensusAddress;
       address operatorAddress = IStakeHub(STAKE_HUB_ADDR).consensusToOperator(validator);
       if (operatorAddress != address(0)) {
-        validator = IStakeHub(STAKE_HUB_ADDR).getValidatorConsensusAddress(operatorAddress);
+        latestConsensusAddress = IStakeHub(STAKE_HUB_ADDR).getValidatorConsensusAddress(operatorAddress);
       }
 
       // record the jailed validator in validatorSet
       for (uint k; k<_validatorSet.length; ++k) {
-        if (_validatorSet[k].consensusAddress == validator) {
+        if (_validatorSet[k].consensusAddress == validator || _validatorSet[k].consensusAddress == latestConsensusAddress) {
           _validatorSet[k].jailed = true;
           break;
         }

--- a/contracts/interface/IStakeHub.sol
+++ b/contracts/interface/IStakeHub.sol
@@ -6,6 +6,9 @@ interface IStakeHub {
     function doubleSignSlash(address validator) external;
     function voteToOperator(bytes calldata voteAddress) external view returns (address);
     function consensusToOperator(address validator) external view returns (address);
+    function getValidatorConsensusAddress(address validator) external view returns (address);
+    function getValidatorCreditContract(address validator) external view returns (address);
+    function getValidatorVoteAddress(address validator) external view returns (bytes memory);
     function maxElectedValidators() external view returns (uint256);
     function distributeReward(address validator) external payable;
 }

--- a/test/Governor.t.sol
+++ b/test/Governor.t.sol
@@ -226,7 +226,7 @@ contract GovernorTest is Deployer {
             consensusAddress, blsPubKey, blsProof, commission, description
         );
 
-        (, credit,,,,) = stakeHub.getValidatorBasicInfo(operatorAddress);
+        credit = stakeHub.getValidatorCreditContract(operatorAddress);
     }
 
     function _encodeValidatorSetUpdatePack(

--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -49,7 +49,8 @@ contract StakeHubTest is Deployer {
     function testCreateValidator() public {
         // create validator success
         (address validator,) = _createValidator(2000 ether);
-        (address consensusAddress,,, bytes memory voteAddress,,) = stakeHub.getValidatorBasicInfo(validator);
+        address consensusAddress = stakeHub.getValidatorConsensusAddress(validator);
+        bytes memory voteAddress = stakeHub.getValidatorVoteAddress(validator);
 
         address operatorAddress = _getNextUserAddress();
         vm.startPrank(operatorAddress);
@@ -104,7 +105,7 @@ contract StakeHubTest is Deployer {
         vm.expectEmit(true, true, false, true, address(stakeHub));
         emit ConsensusAddressEdited(validator, newConsensusAddress);
         stakeHub.editConsensusAddress(newConsensusAddress);
-        (address realConsensusAddr,,,,,) = stakeHub.getValidatorBasicInfo(validator);
+        address realConsensusAddr = stakeHub.getValidatorConsensusAddress(validator);
         assertEq(realConsensusAddr, newConsensusAddress);
 
         // edit commission rate
@@ -139,7 +140,7 @@ contract StakeHubTest is Deployer {
         vm.expectEmit(true, false, false, true, address(stakeHub));
         emit VoteAddressEdited(validator, newVoteAddress);
         stakeHub.editVoteAddress(newVoteAddress, blsProof);
-        (,,, bytes memory realVoteAddr,,) = stakeHub.getValidatorBasicInfo(validator);
+        bytes memory realVoteAddr = stakeHub.getValidatorVoteAddress(validator);
         assertEq(realVoteAddr, newVoteAddress);
 
         vm.stopPrank();
@@ -297,7 +298,7 @@ contract StakeHubTest is Deployer {
 
         // 2. distribute reward
         uint256 reward = 100 ether;
-        (address consensusAddress,,,,,) = stakeHub.getValidatorBasicInfo(validator);
+        address consensusAddress = stakeHub.getValidatorConsensusAddress(validator);
         vm.expectEmit(true, true, false, true, address(stakeHub));
         emit RewardDistributed(validator, reward);
         vm.deal(VALIDATOR_CONTRACT_ADDR, VALIDATOR_CONTRACT_ADDR.balance + reward);
@@ -347,7 +348,7 @@ contract StakeHubTest is Deployer {
         vm.prank(delegator);
         stakeHub.delegate{ value: 100 ether }(validator, false);
 
-        (address consensusAddress,,,,,) = stakeHub.getValidatorBasicInfo(validator);
+        address consensusAddress = stakeHub.getValidatorConsensusAddress(validator);
         vm.deal(VALIDATOR_CONTRACT_ADDR, VALIDATOR_CONTRACT_ADDR.balance + reward);
         vm.prank(VALIDATOR_CONTRACT_ADDR);
         stakeHub.distributeReward{ value: reward }(consensusAddress);
@@ -375,7 +376,7 @@ contract StakeHubTest is Deployer {
         assertApproxEqAbs(preDelegatorBnbAmount, curDelegatorBnbAmount, 1); // there may be 1 delta due to the precision
 
         // unjail
-        (,,,, bool jailed,) = stakeHub.getValidatorBasicInfo(validator);
+        (, bool jailed,) = stakeHub.getValidatorBasicInfo(validator);
         assertEq(jailed, true);
         vm.expectRevert();
         stakeHub.unjail(validator);
@@ -383,7 +384,7 @@ contract StakeHubTest is Deployer {
         vm.expectEmit(true, false, false, true, address(stakeHub));
         emit ValidatorUnjailed(validator);
         stakeHub.unjail(validator);
-        (,,,, jailed,) = stakeHub.getValidatorBasicInfo(validator);
+        (, jailed,) = stakeHub.getValidatorBasicInfo(validator);
         assertEq(jailed, false);
 
         vm.stopPrank();
@@ -400,7 +401,7 @@ contract StakeHubTest is Deployer {
         vm.prank(delegator);
         stakeHub.delegate{ value: 100 ether }(validator, false);
 
-        (address consensusAddress,,,,,) = stakeHub.getValidatorBasicInfo(validator);
+        address consensusAddress = stakeHub.getValidatorConsensusAddress(validator);
         vm.deal(VALIDATOR_CONTRACT_ADDR, VALIDATOR_CONTRACT_ADDR.balance + reward);
         vm.prank(VALIDATOR_CONTRACT_ADDR);
         stakeHub.distributeReward{ value: reward }(consensusAddress);
@@ -432,7 +433,8 @@ contract StakeHubTest is Deployer {
         vm.prank(delegator);
         stakeHub.delegate{ value: 100 ether }(validator, false);
 
-        (address consensusAddress,,, bytes memory voteAddr,,) = stakeHub.getValidatorBasicInfo(validator);
+        address consensusAddress = stakeHub.getValidatorConsensusAddress(validator);
+        bytes memory voteAddr = stakeHub.getValidatorVoteAddress(validator);
         vm.deal(VALIDATOR_CONTRACT_ADDR, VALIDATOR_CONTRACT_ADDR.balance + reward);
         vm.prank(VALIDATOR_CONTRACT_ADDR);
         stakeHub.distributeReward{ value: reward }(consensusAddress);
@@ -473,7 +475,8 @@ contract StakeHubTest is Deployer {
         for (uint256 i; i < length; ++i) {
             votingPower = (2000 + uint64(i) * 2 + 1) * 1e8;
             (operatorAddress,) = _createValidator(uint256(votingPower) * 1e10);
-            (consensusAddress,,, voteAddress,,) = stakeHub.getValidatorBasicInfo(operatorAddress);
+            consensusAddress = stakeHub.getValidatorConsensusAddress(operatorAddress);
+            voteAddress = stakeHub.getValidatorVoteAddress(operatorAddress);
             newConsensusAddrs[length - i - 1] = consensusAddress;
             newVotingPower[length - i - 1] = votingPower;
             newVoteAddrs[length - i - 1] = voteAddress;
@@ -522,7 +525,8 @@ contract StakeHubTest is Deployer {
         for (uint256 i; i < length; ++i) {
             votingPower = (2000 + uint64(i) * 2 + 1) * 1e8;
             (operatorAddress,) = _createValidator(uint256(votingPower) * 1e10);
-            (consensusAddress,,, voteAddress,,) = stakeHub.getValidatorBasicInfo(operatorAddress);
+            consensusAddress = stakeHub.getValidatorConsensusAddress(operatorAddress);
+            voteAddress = stakeHub.getValidatorVoteAddress(operatorAddress);
             newConsensusAddrs[length - i - 1] = consensusAddress;
             newVotingPower[length - i - 1] = votingPower;
             newVoteAddrs[length - i - 1] = voteAddress;
@@ -611,7 +615,7 @@ contract StakeHubTest is Deployer {
             consensusAddress, blsPubKey, blsProof, commission, description
         );
 
-        (, credit,,,,) = stakeHub.getValidatorBasicInfo(operatorAddress);
+        credit = stakeHub.getValidatorCreditContract(operatorAddress);
     }
 
     function _encodeValidatorSetUpdatePack(

--- a/test/TokenRecoverPortal.t.sol
+++ b/test/TokenRecoverPortal.t.sol
@@ -46,7 +46,11 @@ contract TokenRecoverPortalTest is Deployer {
         tokenRecoverPortal.initialize();
     }
 
-    function setUpContractParams(address newApprovalAddress, bytes memory newMerkleRoot, address newProtector) internal {
+    function setUpContractParams(
+        address newApprovalAddress,
+        bytes memory newMerkleRoot,
+        address newProtector
+    ) internal {
         // set the approvalAddress, merkleRoot and tokenRecoverPortalProtector
         bytes memory key = "approvalAddress";
         bytes memory value = abi.encodePacked(newApprovalAddress);
@@ -66,14 +70,24 @@ contract TokenRecoverPortalTest is Deployer {
     }
 
     function setUpContractParamsWithWrongApprovelAddress() public {
-        setUpContractParams(address(0x561319e67357fa3d2b51E58d011a80EB6268A0f5), hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554", protector);
+        setUpContractParams(
+            address(0x561319e67357fa3d2b51E58d011a80EB6268A0f5),
+            hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554",
+            protector
+        );
     }
 
     function setUpContractParamsWithWrongMerkleRoot() public {
-        setUpContractParams(approvalAddress, hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554", protector);
+        setUpContractParams(
+            approvalAddress, hex"11111111047904a8fdaec42e4785295167f7fd63742b309afeb84bd71f8e6554", protector
+        );
     }
 
-    function recoverParams() internal view returns (bytes32, uint256, bytes memory, bytes memory, bytes memory, bytes32[] memory) {
+    function recoverParams()
+        internal
+        view
+        returns (bytes32, uint256, bytes memory, bytes memory, bytes memory, bytes32[] memory)
+    {
         bytes32 tokenSymbol = testTokenSymbol;
         uint256 amount = 14188000000;
         bytes memory ownerPubKey = hex"036d5d41cd7da2e96d39bcbd0390bfed461a86382f7a2923436ff16c65cabc7719";
@@ -106,174 +120,186 @@ contract TokenRecoverPortalTest is Deployer {
     function testRecoverFaildWithWrongApprovalAddress() public {
         setUpContractParamsWithWrongApprovelAddress();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongMerkleRoot() public {
         setUpContractParamsWithWrongMerkleRoot();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongRecipient() public {
         setUpCorrectContractParams();
         vm.prank(address(0x561319e67357fa3d2b51E58d011a80EB6268A0f5));
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongTokenSymbol() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         tokenSymbol = hex"4241110000000000000000000000000000000000000000000000000000000000";
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongAmount() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         amount = 188000001;
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongOwnerPubKey() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
 
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         vm.expectRevert();
         vm.mockCall(address(0x69), "", hex"1111100f29effb427fb76a185b4ac73ea09a534b");
         ownerPubKey = hex"11111111cd7da2e96d39bcbd0390bfed461a86382f7a2923436ff16c65cabc7720";
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongOwnerSignature() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
 
-        ownerSignature = hex"111111117f2b002b4746025f7e803a43e57a397ea66f3939d05302eb7851bbbc0773cda87aae0fbb1e2a29367b606209ed47dc5cba6d1a83f6b79cb70e56efdb";
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
+
+        ownerSignature =
+            hex"111111117f2b002b4746025f7e803a43e57a397ea66f3939d05302eb7851bbbc0773cda87aae0fbb1e2a29367b606209ed47dc5cba6d1a83f6b79cb70e56efdb";
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongApprovalSignature() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
 
-        approvalSignature = hex"1111111180beb068d82413cac31c1df0540dc6a61eddec9f31b94419e60b6c586e5342552f4c8034a00c876d640abea8c5ba9c4d72145d0e562fedd09fe1e00a02";
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
+
+        approvalSignature =
+            hex"1111111180beb068d82413cac31c1df0540dc6a61eddec9f31b94419e60b6c586e5342552f4c8034a00c876d640abea8c5ba9c4d72145d0e562fedd09fe1e00a02";
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecoverFaildWithWrongMerkleProof() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         merkleProof[13] = hex"1111111190245e6a9e1e969ae3f6f0315ea073606fd6fabe9f3d7514c84fee98";
         vm.expectRevert();
         // failed to recover the token
-        tokenRecoverPortal.recover(
-            tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
+        tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);
     }
 
     function testRecover() public {
         setUpCorrectContractParams();
         vm.prank(mockUser);
-        
-        (bytes32 tokenSymbol,
-         uint256 amount,
-         bytes memory ownerPubKey, 
-         bytes memory ownerSignature, 
-         bytes memory approvalSignature,
-         bytes32[] memory merkleProof) = recoverParams();
+
+        (
+            bytes32 tokenSymbol,
+            uint256 amount,
+            bytes memory ownerPubKey,
+            bytes memory ownerSignature,
+            bytes memory approvalSignature,
+            bytes32[] memory merkleProof
+        ) = recoverParams();
 
         // recover the token
         tokenRecoverPortal.recover(tokenSymbol, amount, ownerPubKey, ownerSignature, approvalSignature, merkleProof);

--- a/test/utils/interface/IStakeHub.sol
+++ b/test/utils/interface/IStakeHub.sol
@@ -131,15 +131,10 @@ interface StakeHub {
     function getValidatorBasicInfo(address operatorAddress)
         external
         view
-        returns (
-            address consensusAddress,
-            address creditContract,
-            uint256 createdTime,
-            bytes memory voteAddress,
-            bool jailed,
-            uint256 jailUntil
-        );
+        returns (uint256 createdTime, bool jailed, uint256 jailUntil);
     function getValidatorCommission(address operatorAddress) external view returns (Commission memory);
+    function getValidatorConsensusAddress(address operatorAddress) external view returns (address consensusAddress);
+    function getValidatorCreditContract(address operatorAddress) external view returns (address creditContract);
     function getValidatorDescription(address operatorAddress) external view returns (Description memory);
     function getValidatorElectionInfo(
         uint256 offset,
@@ -155,6 +150,7 @@ interface StakeHub {
         );
     function getValidatorRewardRecord(address operatorAddress, uint256 index) external view returns (uint256);
     function getValidatorTotalPooledBNBRecord(address operatorAddress, uint256 index) external view returns (uint256);
+    function getValidatorVoteAddress(address operatorAddress) external view returns (bytes memory voteAddress);
     function getValidators(
         uint256 offset,
         uint256 limit

--- a/test/utils/interface/ITokenRecoverPortal.sol
+++ b/test/utils/interface/ITokenRecoverPortal.sol
@@ -27,7 +27,7 @@ interface TokenRecoverPortal {
     event Paused();
     event ProtectorChanged(address indexed oldProtector, address indexed newProtector);
     event Resumed();
-    event TokenRecoverRequested(bytes32 tokenSymbol, address account, uint256 amount);
+    event TokenRecoverRequested(bytes ownerAddress, bytes32 tokenSymbol, address account, uint256 amount);
     event UnBlackListed(address indexed target);
 
     function BC_FUSION_CHANNELID() external view returns (uint8);


### PR DESCRIPTION
### Description

This pr is to fix an issue that a validator could avoid being slashed by editing consensus address
