### PR TITLE
fix: transfer BNB back to tokenHub when `_doMigration` failed

### DIFF
--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -275,7 +275,7 @@ contract StakeHub is System, Initializable, Protectable {
     function handleSynPackage(
         uint8,
         bytes calldata msgBytes
-    ) external onlyCrossChainContract enableReceivingFund returns (bytes memory) {
+    ) external onlyCrossChainContract whenNotPaused enableReceivingFund returns (bytes memory) {
         (StakeMigrationPackage memory migrationPkg, bool decodeSuccess) = _decodeMigrationSynPackage(msgBytes);
         if (!decodeSuccess) revert InvalidSynPackage();
 
@@ -1033,11 +1033,7 @@ contract StakeHub is System, Initializable, Protectable {
         return (migrationPackage, success);
     }
 
-    function _doMigration(StakeMigrationPackage memory migrationPkg)
-        internal
-        whenNotPaused
-        returns (StakeMigrationRespCode)
-    {
+    function _doMigration(StakeMigrationPackage memory migrationPkg) internal returns (StakeMigrationRespCode) {
         if (blackList[migrationPkg.delegator] || migrationPkg.delegator == address(0)) {
             return StakeMigrationRespCode.INVALID_DELEGATOR;
         }


### PR DESCRIPTION
### Description

This pr is to fix an error within `StakeHub`.

### Rationale

The BNB should be refunded to `TokenHub` if stake migration failed.

### Changes

Notable changes:
* transfer BNB back to `TokenHub` when `_doMigration` failed