### PR TITLE
fix: transfer BNB back to tokenHub when `_doMigration` failed

### DIFF
--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -552,6 +552,7 @@ contract StakeHubTest is Deployer {
         emit MigrateFailed(delegator, delegator, delegation, StakeMigrationRespCode.VALIDATOR_NOT_EXISTED);
         vm.prank(address(crossChain));
         stakeHub.handleSynPackage(BC_FUSION_CHANNELID, elements.encodeList());
+        assertEq(address(stakeHub).balance, 0, "StakeHub balance should be 0");
 
         // failed for claim fund failed
         elements[0] = validator.encodeAddress();


### PR DESCRIPTION
### Description

This pr is to fix an error within `StakeHub`.

### Rationale

The BNB should be refunded to `TokenHub` if stake migration failed.

### Changes

Notable changes:
* transfer BNB back to `TokenHub` when `_doMigration` failed