### PR TITLE
feat: define turnLength and systemRewardAntiMEVRatio for BEP-341

### DIFF
--- a/abi/bscvalidatorset.abi
+++ b/abi/bscvalidatorset.abi
@@ -914,6 +914,19 @@
   },
   {
     "type": "function",
+    "name": "getTurnLength",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "getValidators",
     "inputs": [],
     "outputs": [
@@ -1239,7 +1252,20 @@
   },
   {
     "type": "function",
-    "name": "systemRewardRatio",
+    "name": "systemRewardAntiMEVRatio",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "systemRewardBaseRatio",
     "inputs": [],
     "outputs": [
       {
@@ -1253,6 +1279,19 @@
   {
     "type": "function",
     "name": "totalInComing",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "turnLength",
     "inputs": [],
     "outputs": [
       {

--- a/test/SlashIndicator.t.sol
+++ b/test/SlashIndicator.t.sol
@@ -8,7 +8,7 @@ contract SlashIndicatorTest is Deployer {
 
     uint256 public burnRatio;
     uint256 public burnRatioScale;
-    uint256 public systemRewardRatio;
+    uint256 public systemRewardBaseRatio;
     uint256 public systemRewardRatioScale;
 
     address public coinbase;
@@ -20,8 +20,8 @@ contract SlashIndicatorTest is Deployer {
             bscValidatorSet.isSystemRewardIncluded() ? bscValidatorSet.burnRatio() : bscValidatorSet.INIT_BURN_RATIO();
         burnRatioScale = bscValidatorSet.BLOCK_FEES_RATIO_SCALE();
 
-        systemRewardRatio = bscValidatorSet.isSystemRewardIncluded()
-            ? bscValidatorSet.systemRewardRatio()
+        systemRewardBaseRatio = bscValidatorSet.isSystemRewardIncluded()
+            ? bscValidatorSet.systemRewardBaseRatio()
             : bscValidatorSet.INIT_SYSTEM_REWARD_RATIO();
         systemRewardRatioScale = bscValidatorSet.BLOCK_FEES_RATIO_SCALE();
 
@@ -434,7 +434,13 @@ contract SlashIndicatorTest is Deployer {
     }
 
     function _calcIncoming(uint256 value) internal view returns (uint256 incoming) {
-        uint256 toSystemReward = (value * systemRewardRatio) / systemRewardRatioScale;
+        uint256 turnLength = bscValidatorSet.getTurnLength();
+        uint256 systemRewardAntiMEVRatio = bscValidatorSet.systemRewardAntiMEVRatio();
+        uint256 systemRewardRatio = systemRewardBaseRatio;
+        if (turnLength > 1 && systemRewardAntiMEVRatio > 0) {
+            systemRewardRatio += systemRewardAntiMEVRatio * (block.number % turnLength) / (turnLength - 1);
+        }
+        uint256 toSystemReward = (value * systemRewardBaseRatio) / systemRewardRatioScale;
         uint256 toBurn = (value * burnRatio) / burnRatioScale;
         incoming = value - toSystemReward - toBurn;
     }

--- a/test/utils/interface/IBSCValidatorSet.sol
+++ b/test/utils/interface/IBSCValidatorSet.sol
@@ -75,6 +75,7 @@ interface BSCValidatorSet {
     function VALIDATORS_UPDATE_MESSAGE_TYPE() external view returns (uint8);
     function VALIDATOR_CONTRACT_ADDR() external view returns (address);
     function alreadyInit() external view returns (bool);
+    function systemRewardAntiMEVRatio() external view returns (uint256);
     function bscChainID() external view returns (uint16);
     function burnRatio() external view returns (uint256);
     function burnRatioInitialized() external view returns (bool);
@@ -102,12 +103,14 @@ interface BSCValidatorSet {
     function getIncoming(address validator) external view returns (uint256);
     function getLivingValidators() external view returns (address[] memory, bytes[] memory);
     function getMiningValidators() external view returns (address[] memory, bytes[] memory);
+    function getTurnLength() external view returns (uint256);
     function getValidators() external view returns (address[] memory);
     function getWorkingValidatorCount() external view returns (uint256 workingValidatorCount);
     function handleAckPackage(uint8 channelId, bytes memory msgBytes) external;
     function handleFailAckPackage(uint8 channelId, bytes memory msgBytes) external;
     function handleSynPackage(uint8, bytes memory msgBytes) external returns (bytes memory responsePayload);
     function init() external;
+    function systemRewardBaseRatio() external view returns (uint256);
     function isCurrentValidator(address validator) external view returns (bool);
     function isMonitoredForMaliciousVote(bytes memory voteAddr) external view returns (bool);
     function isSystemRewardIncluded() external view returns (bool);
@@ -124,8 +127,8 @@ interface BSCValidatorSet {
     function previousHeight() external view returns (uint256);
     function previousVoteAddrFullSet(uint256) external view returns (bytes memory);
     function removeTmpMigratedValidator(address validator) external;
-    function systemRewardRatio() external view returns (uint256);
     function totalInComing() external view returns (uint256);
+    function turnLength() external view returns (uint256);
     function updateParam(string memory key, bytes memory value) external;
     function updateValidatorSetV2(
         address[] memory _consensusAddrs,


### PR DESCRIPTION
### Description

feat: define turnLength and systemRewardAntiMEVRatio for BEP-341

### Rationale

tell us why we need these changes...

### Example

two tests will pass by following command
```
cd contracts 
forge test --match-test testDeposit --match-contract ValidatorSetTest
forge test --match-test testGov --match-contract ValidatorSetTest
```

### Changes

Notable changes:
* add each change in a bullet point here
* ...