### PR TITLE
chore: remove init call in unit tests after bc-fusion

### DIFF
--- a/test/Governor.t.sol
+++ b/test/Governor.t.sol
@@ -28,18 +28,6 @@ contract GovernorTest is Deployer {
 
     function setUp() public {
         vm.mockCall(address(0x66), "", hex"01");
-
-        // remove this after fusion fork launched
-        vm.startPrank(block.coinbase);
-        vm.txGasPrice(0);
-        stakeHub.initialize();
-        vm.txGasPrice(0);
-        govToken.initialize();
-        vm.txGasPrice(0);
-        governor.initialize();
-        vm.txGasPrice(0);
-        timelock.initialize();
-        vm.stopPrank();
     }
 
     function testDelegateVote() public {
@@ -109,22 +97,23 @@ contract GovernorTest is Deployer {
 
         assertEq(governor.proposeStarted(), false, "propose should not start");
 
-        // govBNB totalSupply not enough
-        vm.expectRevert();
-        uint256 proposalId = governor.propose(targets, values, calldatas, description);
-        assertEq(governor.proposeStarted(), false, "propose should not start");
-
-        bnbAmount = 1 ether;
-        stakeHub.delegate{ value: bnbAmount }(validator, false);
-        proposalId = governor.propose(targets, values, calldatas, description);
-        assertEq(governor.proposeStarted(), true, "propose should start");
-
-        bnbAmount = 10000000 ether - 2000 ether;
-        govBNBBalance = govToken.balanceOf(delegator);
-        console.log("govBNBBalance", govBNBBalance);
-        assertEq(govBNBBalance, bnbAmount);
-        assertEq(govToken.getVotes(delegator), govBNBBalance);
-        console.log("voting power before undelegate", govToken.getVotes(delegator));
+        // mainnet totalSupply is already enough
+//        // govBNB totalSupply not enough
+//        vm.expectRevert();
+//        uint256 proposalId = governor.propose(targets, values, calldatas, description);
+//        assertEq(governor.proposeStarted(), false, "propose should not start");
+//
+//        bnbAmount = 1 ether;
+//        stakeHub.delegate{ value: bnbAmount }(validator, false);
+//        proposalId = governor.propose(targets, values, calldatas, description);
+//        assertEq(governor.proposeStarted(), true, "propose should start");
+//
+//        bnbAmount = 10000000 ether - 2000 ether;
+//        govBNBBalance = govToken.balanceOf(delegator);
+//        console.log("govBNBBalance", govBNBBalance);
+//        assertEq(govBNBBalance, bnbAmount);
+//        assertEq(govToken.getVotes(delegator), govBNBBalance);
+//        console.log("voting power before undelegate", govToken.getVotes(delegator));
 
         // voting power changed after undelegating staking share
         bnbAmount = 1 ether;

--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -39,11 +39,6 @@ contract StakeHubTest is Deployer {
 
     function setUp() public {
         vm.mockCall(address(0x66), "", hex"01");
-
-        // remove this after fusion fork launched
-        vm.prank(block.coinbase);
-        vm.txGasPrice(0);
-        stakeHub.initialize();
     }
 
     function testCreateValidator() public {

--- a/test/TokenRecoverPortal.t.sol
+++ b/test/TokenRecoverPortal.t.sol
@@ -39,11 +39,6 @@ contract TokenRecoverPortalTest is Deployer {
 
     function setUp() public {
         vm.mockCall(address(0x69), "", mockTokenOwner);
-
-        // remove this after fusion fork launched
-        vm.prank(block.coinbase);
-        vm.txGasPrice(0);
-        tokenRecoverPortal.initialize();
     }
 
     function setUpContractParams(

--- a/test/utils/Deployer.sol
+++ b/test/utils/Deployer.sol
@@ -80,8 +80,7 @@ contract Deployer is Test {
     event paramChange(string key, bytes value);
 
     constructor() {
-        // create fork
-        // you should modify this for your own test, which generally should be the bsc mainnet latest number
+        // create fork of mainnet
         vm.createSelectFork("bsc");
 
         // setup system contracts


### PR DESCRIPTION
### Description

This pr is to fix errors in unit tests

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* remove init call in unit tests after bc-fusion