### PR TITLE
feat: add agent address for validators

### DIFF
--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -91,6 +91,8 @@ contract StakeHub is System, Initializable, Protectable {
     error InvalidSynPackage();
     // @notice signature: 0xbebdc757
     error InvalidAgent();
+    // @notice signature: 0x682a6e7c
+    error InvalidValidator();
 
     /*----------------- storage -----------------*/
     uint8 private _receiveFundStatus;
@@ -359,7 +361,7 @@ contract StakeHub is System, Initializable, Protectable {
         // basic check
         address operatorAddress = msg.sender;
         if (_validatorSet.contains(operatorAddress)) revert ValidatorExisted();
-        if (agentToOperator[operatorAddress] != address(0)) revert InvalidAgent();
+        if (agentToOperator[operatorAddress] != address(0)) revert InvalidValidator();
 
         if (consensusToOperator[consensusAddress] != address(0) || _legacyConsensusAddress[consensusAddress]) {
             revert DuplicateConsensusAddress();

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -414,14 +414,14 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(_getMsgSender())
+        validatorExist(_bep410MsgSender())
     {
         if (newConsensusAddress == address(0)) revert InvalidConsensusAddress();
         if (consensusToOperator[newConsensusAddress] != address(0) || _legacyConsensusAddress[newConsensusAddress]) {
             revert DuplicateConsensusAddress();
         }
 
-        address operatorAddress = _getMsgSender();
+        address operatorAddress = _bep410MsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -440,9 +440,9 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(_getMsgSender())
+        validatorExist(_bep410MsgSender())
     {
-        address operatorAddress = _getMsgSender();
+        address operatorAddress = _bep410MsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -466,9 +466,9 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(_getMsgSender())
+        validatorExist(_bep410MsgSender())
     {
-        address operatorAddress = _getMsgSender();
+        address operatorAddress = _bep410MsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -486,9 +486,9 @@ contract StakeHub is System, Initializable, Protectable {
     function editVoteAddress(
         bytes calldata newVoteAddress,
         bytes calldata blsProof
-    ) external whenNotPaused notInBlackList validatorExist(_getMsgSender()) {
+    ) external whenNotPaused notInBlackList validatorExist(_bep410MsgSender()) {
         // proof-of-possession verify
-        address operatorAddress = _getMsgSender();
+        address operatorAddress = _bep410MsgSender();
         if (!_checkVoteAddress(operatorAddress, newVoteAddress, blsProof)) revert InvalidVoteAddress();
         if (voteToOperator[newVoteAddress] != address(0) || _legacyVoteAddress[newVoteAddress]) {
             revert DuplicateVoteAddress();
@@ -1210,7 +1210,7 @@ contract StakeHub is System, Initializable, Protectable {
         emit Claimed(operatorAddress, msg.sender, bnbAmount);
     }
 
-    function _getMsgSender() internal view returns (address) {
+    function _bep410MsgSender() internal view returns (address) {
         if (agentToOperator[msg.sender] != address(0)) {
             return agentToOperator[msg.sender];
         }

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -169,7 +169,6 @@ contract StakeHub is System, Initializable, Protectable {
         bool jailed;
         uint256 jailUntil;
         uint256 updateTime;
-
         // The agent can perform transactions on behalf of the operatorAddress in certain scenarios.
         address agent;
         uint256[19] __reservedSlots;

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -89,6 +89,8 @@ contract StakeHub is System, Initializable, Protectable {
     error ConsensusAddressExpired();
     // @notice signature: 0x0d7b78d4
     error InvalidSynPackage();
+    // @notice signature: 0xbebdc757
+    error InvalidAgent();
 
     /*----------------- storage -----------------*/
     uint8 private _receiveFundStatus;
@@ -135,6 +137,9 @@ contract StakeHub is System, Initializable, Protectable {
     // slash key => slash jail time
     mapping(bytes32 => uint256) private _felonyRecords;
 
+    // agent => validator operator address
+    mapping(address => address) public agentToOperator;
+
     /*----------------- structs and events -----------------*/
     struct StakeMigrationPackage {
         address operatorAddress; // the operator address of the target validator to delegate to
@@ -162,7 +167,10 @@ contract StakeHub is System, Initializable, Protectable {
         bool jailed;
         uint256 jailUntil;
         uint256 updateTime;
-        uint256[20] __reservedSlots;
+
+        // The agent can perform transactions on behalf of the operatorAddress in certain scenarios.
+        address agent;
+        uint256[19] __reservedSlots;
     }
 
     struct Description {
@@ -219,6 +227,7 @@ contract StakeHub is System, Initializable, Protectable {
         address indexed operatorAddress, address indexed delegator, uint256 bnbAmount, StakeMigrationRespCode respCode
     );
     event UnexpectedPackage(uint8 channelId, bytes msgBytes);
+    event AgentChanged(address indexed operatorAddress, address indexed oldAgent, address indexed newAgent);
 
     /*----------------- modifiers -----------------*/
     modifier validatorExist(address operatorAddress) {
@@ -315,6 +324,24 @@ contract StakeHub is System, Initializable, Protectable {
     }
 
     /*----------------- external functions -----------------*/
+    function updateAgent(address newAgent) external validatorExist(msg.sender) {
+        if (agentToOperator[newAgent] != address(0)) revert InvalidAgent();
+        if (_validatorSet.contains(newAgent)) revert InvalidAgent();
+
+        address operatorAddress = msg.sender;
+        address oldAgent = _validators[operatorAddress].agent;
+        if (oldAgent == newAgent) revert InvalidAgent();
+
+        if (oldAgent != address(0)) {
+            agentToOperator[oldAgent] = address(0);
+        }
+
+        _validators[operatorAddress].agent = newAgent;
+        agentToOperator[newAgent] = operatorAddress;
+
+        emit AgentChanged(operatorAddress, oldAgent, newAgent);
+    }
+
     /**
      * @param consensusAddress the consensus address of the validator
      * @param voteAddress the vote address of the validator
@@ -332,6 +359,8 @@ contract StakeHub is System, Initializable, Protectable {
         // basic check
         address operatorAddress = msg.sender;
         if (_validatorSet.contains(operatorAddress)) revert ValidatorExisted();
+        if (agentToOperator[operatorAddress] != address(0)) revert InvalidAgent();
+
         if (consensusToOperator[consensusAddress] != address(0) || _legacyConsensusAddress[consensusAddress]) {
             revert DuplicateConsensusAddress();
         }
@@ -384,14 +413,14 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(msg.sender)
+        validatorExist(_getMsgSender())
     {
         if (newConsensusAddress == address(0)) revert InvalidConsensusAddress();
         if (consensusToOperator[newConsensusAddress] != address(0) || _legacyConsensusAddress[newConsensusAddress]) {
             revert DuplicateConsensusAddress();
         }
 
-        address operatorAddress = msg.sender;
+        address operatorAddress = _getMsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -410,9 +439,9 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(msg.sender)
+        validatorExist(_getMsgSender())
     {
-        address operatorAddress = msg.sender;
+        address operatorAddress = _getMsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -436,9 +465,9 @@ contract StakeHub is System, Initializable, Protectable {
         external
         whenNotPaused
         notInBlackList
-        validatorExist(msg.sender)
+        validatorExist(_getMsgSender())
     {
-        address operatorAddress = msg.sender;
+        address operatorAddress = _getMsgSender();
         Validator storage valInfo = _validators[operatorAddress];
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
@@ -456,9 +485,9 @@ contract StakeHub is System, Initializable, Protectable {
     function editVoteAddress(
         bytes calldata newVoteAddress,
         bytes calldata blsProof
-    ) external whenNotPaused notInBlackList validatorExist(msg.sender) {
+    ) external whenNotPaused notInBlackList validatorExist(_getMsgSender()) {
         // proof-of-possession verify
-        address operatorAddress = msg.sender;
+        address operatorAddress = _getMsgSender();
         if (!_checkVoteAddress(operatorAddress, newVoteAddress, blsProof)) revert InvalidVoteAddress();
         if (voteToOperator[newVoteAddress] != address(0) || _legacyVoteAddress[newVoteAddress]) {
             revert DuplicateVoteAddress();
@@ -1178,5 +1207,13 @@ contract StakeHub is System, Initializable, Protectable {
     function _claim(address operatorAddress, uint256 requestNumber) internal validatorExist(operatorAddress) {
         uint256 bnbAmount = IStakeCredit(_validators[operatorAddress].creditContract).claim(msg.sender, requestNumber);
         emit Claimed(operatorAddress, msg.sender, bnbAmount);
+    }
+
+    function _getMsgSender() internal view returns (address) {
+        if (agentToOperator[msg.sender] != address(0)) {
+            return agentToOperator[msg.sender];
+        }
+
+        return msg.sender;
     }
 }

--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -335,7 +335,7 @@ contract StakeHub is System, Initializable, Protectable {
         if (oldAgent == newAgent) revert InvalidAgent();
 
         if (oldAgent != address(0)) {
-            agentToOperator[oldAgent] = address(0);
+            delete agentToOperator[oldAgent];
         }
 
         _validators[operatorAddress].agent = newAgent;

--- a/test/utils/interface/IStakeHub.sol
+++ b/test/utils/interface/IStakeHub.sol
@@ -51,6 +51,8 @@ interface StakeHub {
     error ValidatorNotJailed();
     error VoteAddressExpired();
     error ZeroShares();
+    error InvalidAgent();
+    error InvalidValidator();
 
     event BlackListed(address indexed target);
     event Claimed(address indexed operatorAddress, address indexed delegator, uint256 bnbAmount);
@@ -94,6 +96,7 @@ interface StakeHub {
     );
     event ValidatorUnjailed(address indexed operatorAddress);
     event VoteAddressEdited(address indexed operatorAddress, bytes newVoteAddress);
+    event AgentChanged(address indexed operatorAddress, address indexed oldAgent, address indexed newAgent);
 
     receive() external payable;
 
@@ -179,4 +182,7 @@ interface StakeHub {
     function updateParam(string memory key, bytes memory value) external;
     function voteExpiration(bytes memory) external view returns (uint256);
     function voteToOperator(bytes memory) external view returns (address);
+
+    function agentToOperator(address) external view returns (address);
+    function updateAgent(address newAgent) external;
 }


### PR DESCRIPTION
### Description

add agent address for validators

### Rationale
Agent can execute `editConsensusAddress`, `editCommissionRate`, `editDescription`, `editVoteAddress` for his operator. 


### Changes

Notable changes:
* add agent address for validators
* ...