### PR TITLE
fix: should not change agentToOperator while newAgent is zero address

### DIFF
--- a/contracts/BC_fusion/StakeHub.sol
+++ b/contracts/BC_fusion/StakeHub.sol
@@ -341,7 +341,10 @@ contract StakeHub is System, Initializable, Protectable {
         }
 
         _validators[operatorAddress].agent = newAgent;
-        agentToOperator[newAgent] = operatorAddress;
+
+        if (newAgent != address(0)) {
+            agentToOperator[newAgent] = operatorAddress;
+        }
 
         emit AgentChanged(operatorAddress, oldAgent, newAgent);
     }


### PR DESCRIPTION
### Description

it should not change `agentToOperator` while `newAgent` is zero address in `updateAgent` function

### Example
before this fix:
validator A set agent1 
agentToOperator[address(0)] == address(0)
validator A update agent to address(0)   => caused agentToOperator[address(0)] == validator A

after fix:
validator A set agent1 
agentToOperator[address(0)] == address(0)
validator A update agent to address(0)   => agentToOperator[address(0)] == address(0)

### Changes

Notable changes:
* not change `agentToOperator` while `newAgent` is zero address in `updateAgent` function

* ...