### PR TITLE
fix: update the flatten.sh script

### DIFF
--- a/scripts/flatten.sh
+++ b/scripts/flatten.sh
@@ -1,17 +1,11 @@
-forge flatten contracts/BSCValidatorSet.sol >contracts/flattened/BSCValidatorSet.sol
-forge flatten contracts/GovHub.sol >contracts/flattened/GovHub.sol
-forge flatten contracts/RelayerHub.sol >contracts/flattened/RelayerHub.sol
-forge flatten contracts/RelayerIncentivize.sol >contracts/flattened/RelayerIncentivize.sol
-forge flatten contracts/SlashIndicator.sol >contracts/flattened/SlashIndicator.sol
-forge flatten contracts/SystemReward.sol >contracts/flattened/SystemReward.sol
-forge flatten contracts/TendermintLightClient.sol >contracts/flattened/TendermintLightClient.sol
-forge flatten contracts/TokenHub.sol >contracts/flattened/TokenHub.sol
-forge flatten contracts/CrossChain.sol >contracts/flattened/CrossChain.sol
-forge flatten contracts/TokenManager.sol >contracts/flattened/TokenManager.sol
-forge flatten contracts/Staking.sol >contracts/flattened/Staking.sol
-forge flatten contracts/BC_fusion/StakeHub.sol >contracts/flattened/StakeHub.sol
-forge flatten contracts/BC_fusion/StakeCredit.sol >contracts/flattened/StakeCredit.sol
-forge flatten contracts/BC_fusion/BSCGovernor.sol >contracts/flattened/BSCGovernor.sol
-forge flatten contracts/BC_fusion/GovToken.sol >contracts/flattened/GovToken.sol
-forge flatten contracts/BC_fusion/BSCTimelock.sol >contracts/flattened/BSCTimelock.sol
-forge flatten contracts/BC_fusion/TokenRecoverPortal.sol > contracts/flattened/TokenRecoverPortal.sol
+forge flatten contracts/BSCValidatorSet.sol -o contracts/flattened/BSCValidatorSet.sol
+forge flatten contracts/GovHub.sol -o contracts/flattened/GovHub.sol
+forge flatten contracts/SlashIndicator.sol -o contracts/flattened/SlashIndicator.sol
+forge flatten contracts/SystemReward.sol -o contracts/flattened/SystemReward.sol
+forge flatten contracts/TokenHub.sol -o contracts/flattened/TokenHub.sol
+forge flatten contracts/StakeHub.sol -o contracts/flattened/StakeHub.sol
+forge flatten contracts/StakeCredit.sol -o contracts/flattened/StakeCredit.sol
+forge flatten contracts/BSCGovernor.sol -o contracts/flattened/BSCGovernor.sol
+forge flatten contracts/GovToken.sol -o contracts/flattened/GovToken.sol
+forge flatten contracts/BSCTimelock.sol -o contracts/flattened/BSCTimelock.sol
+forge flatten contracts/TokenRecoverPortal.sol -o contracts/flattened/TokenRecoverPortal.sol


### PR DESCRIPTION
### Description
These 6 contracts were deprecated after BC-Fusion:
```
contracts/deprecated/CrossChain.sol
contracts/deprecated/RelayerHub.sol
contracts/deprecated/RelayerIncentivize.sol
contracts/deprecated/Staking.sol
contracts/deprecated/TendermintLightClient.sol
contracts/deprecated/TokenManager.sol
```

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...