### PR TITLE
fix: expire a rotated key's slash-evidence window from deactivation, not rotation

### DIFF
--- a/contracts/StakeHub.sol
+++ b/contracts/StakeHub.sol
@@ -699,9 +699,13 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (_felonyMap[index] >= maxFelonyBetweenBreatheBlock) revert NoMoreFelonyAllowed();
         _felonyMap[index] += 1;
 
-        // check if the voteAddress has already expired
-        if (voteExpiration[voteAddress] != 0 && voteExpiration[voteAddress] + BREATHE_BLOCK_INTERVAL < block.timestamp)
-        {
+        // Evidence expires one BREATHE_BLOCK_INTERVAL after the vote key leaves the active set.
+        // A rotated-out key deactivates at the next breathe block, so the deadline is
+        // deactivation + BREATHE = (rotationTimestamp / BREATHE + 2) * BREATHE.
+        if (
+            voteExpiration[voteAddress] != 0
+                && (voteExpiration[voteAddress] / BREATHE_BLOCK_INTERVAL + 2) * BREATHE_BLOCK_INTERVAL < block.timestamp
+        ) {
             revert VoteAddressExpired();
         }
 
@@ -734,10 +738,12 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (_felonyMap[index] >= maxFelonyBetweenBreatheBlock) revert NoMoreFelonyAllowed();
         _felonyMap[index] += 1;
 
-        // check if the consensusAddress has already expired
+        // Evidence expires one BREATHE_BLOCK_INTERVAL after the consensus key leaves the active set.
+        // A rotated-out key deactivates at the next breathe block, so the deadline is
+        // deactivation + BREATHE = (rotationTimestamp / BREATHE + 2) * BREATHE.
         if (
             consensusExpiration[consensusAddress] != 0
-                && consensusExpiration[consensusAddress] + BREATHE_BLOCK_INTERVAL < block.timestamp
+                && (consensusExpiration[consensusAddress] / BREATHE_BLOCK_INTERVAL + 2) * BREATHE_BLOCK_INTERVAL < block.timestamp
         ) {
             revert ConsensusAddressExpired();
         }


### PR DESCRIPTION
## Description

On key rotation, `editConsensusAddress` / `editVoteAddress` record the rotation timestamp in `consensusExpiration` / `voteExpiration`. The evidence guard in `doubleSignSlash` / `maliciousVoteSlash` then expires the key's window at `expiration + BREATHE_BLOCK_INTERVAL`.

## Rationale

A rotated-out key only leaves the active validator set at the next daily breathe block, so anchoring the deadline to the rotation timestamp can leave this window inconsistent with the block-based `felonySlashScope`. Anchor it to the key's deactivation (the next breathe block) instead, so the grace is a full `BREATHE_BLOCK_INTERVAL` after the key actually leaves the active set — consistent for any rotation time.

## Changes

- `contracts/StakeHub.sol`: compute the deadline in the two slash checks from the stored rotation timestamp as `(expiration / BREATHE_BLOCK_INTERVAL + 2) * BREATHE_BLOCK_INTERVAL` (= deactivation + `BREATHE_BLOCK_INTERVAL`). This leaves `consensusExpiration` / `voteExpiration` still meaning the rotation timestamp (no storage-semantics change) and only widens the acceptance window, never narrows it. `_bep563MsgSender` (reads only `== 0`) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)