### PR TITLE
docs: note that StakeCredit.slash() intentionally ignores the unbond queue

### DIFF
--- a/contracts/StakeCredit.sol
+++ b/contracts/StakeCredit.sol
@@ -205,6 +205,11 @@ contract StakeCredit is SystemV2, Initializable, ReentrancyGuardUpgradeable, ERC
      * @dev Slash the validator. Only the `StakeHub` contract can call this function.
      * @param slashBnbAmount the amount of BNB to be slashed
      * @return realSlashBnbAmount the real amount of BNB slashed
+     *
+     * @notice Slashing is intentionally limited to the validator's active self-delegation
+     * (`balanceOf(validator)`); amounts recorded in the unbonding queue are outside this
+     * burn. A zero burn is therefore a valid outcome and must not itself cause `slash()`
+     * to revert on consensus-driven slashing paths.
      */
     function slash(
         uint256 slashBnbAmount


### PR DESCRIPTION
## Description

`StakeCredit.slash()` burns only the validator's active self-delegation (`balanceOf(validator)`) and does not reach the 7-day unbonding queue, so a validator that has already undelegated its self-stake is slashed 0.

## Rationale

This is intentional and safe: the unbonded self-stake stays locked for `unbondPeriod` and is claimable only via `StakeHub.claim` (gated by `whenNotPaused` / `notInBlackList`), so `stakeHubProtector` can blacklist the operator or `pause()` within that window to freeze the funds. `slash()` must also not revert on a 0 burn, since it runs on consensus-driven paths.

## Changes

Add a NatSpec `@notice` at `StakeCredit.slash()` documenting the above, so the intent is explicit at the call site. Comment-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)