### PR TITLE
fix: evict the active-set key on slash after rotation, and pay the finality reporter unconditionally

### DIFF
--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -252,15 +252,10 @@ contract SlashIndicator is ISlashIndicator, System, IParamSubscriber, IApplicati
             "verify signature failed"
         );
 
-        // Slash + jail + evict the offender (StakeHub resolves the operator from the vote
-        // address and evicts it). If it reverts (e.g. already slashed / expired), the whole
-        // submission reverts and no reward is paid.
+        // Slash/jail/evict first (reverts on already-slashed/expired, blocking any reward),
+        // then reward the reporter unconditionally as submitDoubleSignEvidence does. The old
+        // living-key loop skipped the reward whenever the vote key had been rotated.
         IStakeHub(STAKE_HUB_ADDR).maliciousVoteSlash(_evidence.voteAddr);
-
-        // Reward the reporter unconditionally, mirroring submitDoubleSignEvidence. The prior
-        // implementation only paid when the vote address matched a CURRENT living validator's
-        // key, so a validator that rotated its vote key between the offence and the report was
-        // still fully slashed while the reporter received nothing.
         uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * felonySlashRewardRatio) / 100;
         ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
     }

--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -252,19 +252,17 @@ contract SlashIndicator is ISlashIndicator, System, IParamSubscriber, IApplicati
             "verify signature failed"
         );
 
-        // reward sender and felony validator if validator found
-        (address[] memory vals, bytes[] memory voteAddrs) =
-            IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
-        for (uint256 i; i < voteAddrs.length; ++i) {
-            if (BytesLib.equal(voteAddrs[i], _evidence.voteAddr)) {
-                uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * felonySlashRewardRatio) / 100;
-                ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
-                IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(vals[i]);
-                break;
-            }
-        }
-
+        // Slash + jail + evict the offender (StakeHub resolves the operator from the vote
+        // address and evicts it). If it reverts (e.g. already slashed / expired), the whole
+        // submission reverts and no reward is paid.
         IStakeHub(STAKE_HUB_ADDR).maliciousVoteSlash(_evidence.voteAddr);
+
+        // Reward the reporter unconditionally, mirroring submitDoubleSignEvidence. The prior
+        // implementation only paid when the vote address matched a CURRENT living validator's
+        // key, so a validator that rotated its vote key between the offence and the report was
+        // still fully slashed while the reporter received nothing.
+        uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * felonySlashRewardRatio) / 100;
+        ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
     }
 
     function submitDoubleSignEvidence(bytes memory header1, bytes memory header2) public onlyInit {

--- a/contracts/StakeHub.sol
+++ b/contracts/StakeHub.sol
@@ -150,6 +150,14 @@ contract StakeHub is SystemV2, Initializable, Protectable {
     // where each NodeID is stored as a fixed 32-byte value.
     mapping(address => bytes32[]) private validatorNodeIDs;
 
+    // operator address => the consensus address held immediately before the most recent
+    // `editConsensusAddress`. Until the next breathe-block sync, BSCValidatorSet's active
+    // set may still be keyed on this pre-rotation address, so slash eviction must target it
+    // as well as the current one. Retained (never cleared) so a felony() on a stale value is
+    // a harmless no-op; consensusToOperator[preConsensusAddress] is likewise retained, so the
+    // address can never be re-registered by another validator.
+    mapping(address => address) public preConsensusAddress;
+
     /*----------------- structs and events -----------------*/
     struct StakeMigrationPackage {
         address operatorAddress; // the operator address of the target validator to delegate to
@@ -404,6 +412,9 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
         consensusExpiration[valInfo.consensusAddress] = block.timestamp;
+        // Remember the pre-rotation key: BSCValidatorSet keeps it in the active set until the
+        // next breathe-block sync, so slash eviction must still be able to reach it.
+        preConsensusAddress[operatorAddress] = valInfo.consensusAddress;
         valInfo.consensusAddress = newConsensusAddress;
         valInfo.updateTime = block.timestamp;
         consensusToOperator[newConsensusAddress] = operatorAddress;
@@ -710,9 +721,11 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (!canSlash) revert AlreadySlashed();
         uint256 slashAmount = IStakeCredit(valInfo.creditContract).slash(felonySlashAmount);
         _jailValidator(valInfo, jailUntil);
-        // Evict using the post-rotation consensus key; SlashIndicator's voteAddr-based
-        // eviction covers the case where BSCValidatorSet has not yet synced K_new.
-        IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valInfo.consensusAddress);
+        // Evict the validator's active-set key. `_felonyActiveKey` targets both the current
+        // and the pre-rotation consensus address, so the eviction lands whether or not the
+        // active set has synced a recent `editConsensusAddress`, and cannot be dodged by
+        // resolving the slash through a chosen key.
+        _felonyActiveKey(valInfo);
 
         emit ValidatorSlashed(operatorAddress, jailUntil, slashAmount, SlashType.MaliciousVote);
 
@@ -747,9 +760,11 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (!canSlash) revert AlreadySlashed();
         uint256 slashAmount = IStakeCredit(valInfo.creditContract).slash(felonySlashAmount);
         _jailValidator(valInfo, jailUntil);
-        // Evict using the post-rotation consensus key; SlashIndicator's felony(K_old)
-        // covers the case where BSCValidatorSet has not yet synced K_new.
-        IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valInfo.consensusAddress);
+        // Evict the validator's active-set key. `_felonyActiveKey` targets both the current
+        // and the pre-rotation consensus address, so a proven double-signer is removed even
+        // when it rotated its key just before offending, and the eviction cannot be dodged by
+        // self-submitting evidence signed with the new key.
+        _felonyActiveKey(valInfo);
 
         emit ValidatorSlashed(operatorAddress, jailUntil, slashAmount, SlashType.DoubleSign);
 
@@ -1227,6 +1242,23 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         return creditProxy;
     }
 
+    /**
+     * @dev Evict a validator from BSCValidatorSet's active set regardless of a pending
+     * consensus-key rotation. Between `editConsensusAddress` and the next breathe-block
+     * sync the active set is still keyed on the pre-rotation address, so felony() on the
+     * current address alone is a no-op. Evicting both the current and the pre-rotation key
+     * always removes whichever one is actually in the active set; felony() on the other is
+     * a harmless no-op. This also means the eviction cannot be dodged by choosing which key
+     * the slash resolves through (e.g. self-submitted evidence signed with the new key).
+     */
+    function _felonyActiveKey(Validator storage valInfo) internal {
+        IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valInfo.consensusAddress);
+        address preAddr = preConsensusAddress[valInfo.operatorAddress];
+        if (preAddr != address(0) && preAddr != valInfo.consensusAddress) {
+            IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(preAddr);
+        }
+    }
+
     function _checkValidatorSelfDelegation(
         address operatorAddress
     ) internal {
@@ -1236,7 +1268,7 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         }
         if (IStakeCredit(valInfo.creditContract).getPooledBNB(operatorAddress) < minSelfDelegationBNB) {
             _jailValidator(valInfo, block.timestamp + downtimeJailTime);
-            IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valInfo.consensusAddress);
+            _felonyActiveKey(valInfo);
         }
     }
 

--- a/contracts/StakeHub.sol
+++ b/contracts/StakeHub.sol
@@ -150,12 +150,8 @@ contract StakeHub is SystemV2, Initializable, Protectable {
     // where each NodeID is stored as a fixed 32-byte value.
     mapping(address => bytes32[]) private validatorNodeIDs;
 
-    // operator address => the consensus address held immediately before the most recent
-    // `editConsensusAddress`. Until the next breathe-block sync, BSCValidatorSet's active
-    // set may still be keyed on this pre-rotation address, so slash eviction must target it
-    // as well as the current one. Retained (never cleared) so a felony() on a stale value is
-    // a harmless no-op; consensusToOperator[preConsensusAddress] is likewise retained, so the
-    // address can never be re-registered by another validator.
+    // operator => consensus address held just before the latest `editConsensusAddress`.
+    // Slash eviction targets it too, since BSCValidatorSet keeps it until the next breathe sync.
     mapping(address => address) public preConsensusAddress;
 
     /*----------------- structs and events -----------------*/
@@ -412,9 +408,7 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (valInfo.updateTime + BREATHE_BLOCK_INTERVAL > block.timestamp) revert UpdateTooFrequently();
 
         consensusExpiration[valInfo.consensusAddress] = block.timestamp;
-        // Remember the pre-rotation key: BSCValidatorSet keeps it in the active set until the
-        // next breathe-block sync, so slash eviction must still be able to reach it.
-        preConsensusAddress[operatorAddress] = valInfo.consensusAddress;
+        preConsensusAddress[operatorAddress] = valInfo.consensusAddress; // for slash eviction pre-sync
         valInfo.consensusAddress = newConsensusAddress;
         valInfo.updateTime = block.timestamp;
         consensusToOperator[newConsensusAddress] = operatorAddress;
@@ -721,10 +715,6 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (!canSlash) revert AlreadySlashed();
         uint256 slashAmount = IStakeCredit(valInfo.creditContract).slash(felonySlashAmount);
         _jailValidator(valInfo, jailUntil);
-        // Evict the validator's active-set key. `_felonyActiveKey` targets both the current
-        // and the pre-rotation consensus address, so the eviction lands whether or not the
-        // active set has synced a recent `editConsensusAddress`, and cannot be dodged by
-        // resolving the slash through a chosen key.
         _felonyActiveKey(valInfo);
 
         emit ValidatorSlashed(operatorAddress, jailUntil, slashAmount, SlashType.MaliciousVote);
@@ -760,10 +750,6 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         if (!canSlash) revert AlreadySlashed();
         uint256 slashAmount = IStakeCredit(valInfo.creditContract).slash(felonySlashAmount);
         _jailValidator(valInfo, jailUntil);
-        // Evict the validator's active-set key. `_felonyActiveKey` targets both the current
-        // and the pre-rotation consensus address, so a proven double-signer is removed even
-        // when it rotated its key just before offending, and the eviction cannot be dodged by
-        // self-submitting evidence signed with the new key.
         _felonyActiveKey(valInfo);
 
         emit ValidatorSlashed(operatorAddress, jailUntil, slashAmount, SlashType.DoubleSign);
@@ -1242,15 +1228,9 @@ contract StakeHub is SystemV2, Initializable, Protectable {
         return creditProxy;
     }
 
-    /**
-     * @dev Evict a validator from BSCValidatorSet's active set regardless of a pending
-     * consensus-key rotation. Between `editConsensusAddress` and the next breathe-block
-     * sync the active set is still keyed on the pre-rotation address, so felony() on the
-     * current address alone is a no-op. Evicting both the current and the pre-rotation key
-     * always removes whichever one is actually in the active set; felony() on the other is
-     * a harmless no-op. This also means the eviction cannot be dodged by choosing which key
-     * the slash resolves through (e.g. self-submitted evidence signed with the new key).
-     */
+    // Evict via both the current and pre-rotation consensus key, so the felony lands on
+    // whichever is actually seated in BSCValidatorSet (the other is a harmless no-op) and
+    // cannot be dodged by the key the slash resolves through.
     function _felonyActiveKey(Validator storage valInfo) internal {
         IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(valInfo.consensusAddress);
         address preAddr = preConsensusAddress[valInfo.operatorAddress];

--- a/test/StakeHub.t.sol
+++ b/test/StakeHub.t.sol
@@ -459,6 +459,55 @@ contract StakeHubTest is Deployer {
         assertApproxEqAbs(preDelegatorBnbAmount, curDelegatorBnbAmount, 1); // there may be 1 delta due to the precision
     }
 
+    // Regression: a validator that rotates its consensus key just after a breathe block and is
+    // then double-sign-slashed through the NEW key (as with self-submitted evidence signed by
+    // K_new) must still be evicted from the active set, where it is seated under the OLD key.
+    // Before the fix, both eviction calls target K_new (not in the active set) and no-op, so the
+    // proven double-signer keeps its active-set seat under K_old until the next breathe sync.
+    function testDoubleSignSlashEvictsActiveKeyAfterRotation() public {
+        // Seat three validators into BSCValidatorSet's active set (felony needs >1 to remove one).
+        uint256 length = 3;
+        address[] memory consensusAddrs = new address[](length);
+        uint64[] memory votingPowers = new uint64[](length);
+        bytes[] memory voteAddrs = new bytes[](length);
+        address attacker;
+        address kOld;
+        for (uint256 i; i < length; ++i) {
+            uint64 vp = (2000 + uint64(i) * 2 + 1) * 1e8;
+            (address op,,,) = _createValidator(uint256(vp) * 1e10);
+            consensusAddrs[i] = stakeHub.getValidatorConsensusAddress(op);
+            votingPowers[i] = vp;
+            voteAddrs[i] = stakeHub.getValidatorVoteAddress(op);
+            if (i == 0) {
+                attacker = op;
+                kOld = consensusAddrs[i];
+            }
+        }
+        vm.prank(block.coinbase);
+        vm.txGasPrice(0);
+        bscValidatorSet.updateValidatorSetV2(consensusAddrs, votingPowers, voteAddrs);
+        assertTrue(bscValidatorSet.isCurrentValidator(kOld), "attacker should be seated under K_old");
+
+        // Rotate to K_new (allowed after the per-validator edit cooldown). BSCValidatorSet's
+        // active set is NOT resynced, so it still holds K_old.
+        vm.warp(block.timestamp + stakeHub.BREATHE_BLOCK_INTERVAL() + 1);
+        address kNew = address(uint160(uint256(keccak256("k-new-rotation"))));
+        vm.prank(attacker);
+        stakeHub.editConsensusAddress(kNew);
+        assertTrue(bscValidatorSet.isCurrentValidator(kOld), "K_old still seated right after rotation");
+        assertEq(stakeHub.consensusToOperator(kNew), attacker, "K_new resolves to the operator");
+
+        // Slash via K_new, as a self-submitted double-sign evidence signed with K_new would.
+        vm.prank(SLASH_CONTRACT_ADDR);
+        stakeHub.doubleSignSlash(kNew);
+
+        // The active-set seat (K_old) must be gone.
+        assertFalse(
+            bscValidatorSet.isCurrentValidator(kOld),
+            "proven double-signer must be evicted from the active set even after key rotation"
+        );
+    }
+
     function testMaliciousVoteSlash() public {
         // totalShares: 2100095458884494749761
         // totalPooledBNB: 2200 ether


### PR DESCRIPTION
### Description

Two coupled fixes on the slashing/eviction path, kept in one PR because the second is only correct once the first is in place.

1. **Evict the active-set consensus key on slash after a rotation.** `BSCValidatorSet.felony(addr)` no-ops when `addr` is not in the active set. Between `editConsensusAddress` (which updates only StakeHub's `consensusAddress` to K_new) and the next breathe-block resync, the active set is still keyed on K_old, so a slash that evicts only the current key can miss. StakeHub now records the pre-rotation key per operator and, in every StakeHub-driven felony (`doubleSignSlash`, `maliciousVoteSlash`, and the self-delegation-floor path), evicts both the current and the pre-rotation key via `_felonyActiveKey`. `felony()` on the non-active key is a harmless no-op, so whichever key is actually seated is removed regardless of how the slash resolved.

2. **Pay the finality-violation reporter unconditionally.** `submitFinalityViolationEvidence` previously paid the reporter only inside a loop that matched the evidence vote address against a CURRENT living validator's key, so a validator that rotated its vote key between the offence and the report was fully slashed while the reporter got nothing. It now calls `maliciousVoteSlash` first (which resolves the operator from the vote address, evicts it, and reverts the whole submission on already-slashed/expired) and then pays the reporter unconditionally, mirroring `submitDoubleSignEvidence`.

### Rationale

Fix 2 removes the loop's `felony(vals[i])`, which in the pre-resync consensus-rotation window was the only call that targeted the active-set key K_old; the remaining `maliciousVoteSlash` eviction targets K_new and would no-op there. Fix 1 makes `maliciousVoteSlash` evict both keys, so removing that loop is safe. Shipping them together avoids a window where fix 2 alone would weaken malicious-vote eviction.

### Changes

- `StakeHub`: record the pre-rotation consensus address in `editConsensusAddress`; add `_felonyActiveKey` and use it from `doubleSignSlash`, `maliciousVoteSlash`, and `_checkValidatorSelfDelegation` (new mapping appended to storage, upgrade-safe).
- `SlashIndicator`: in `submitFinalityViolationEvidence`, slash first then pay the reporter unconditionally; remove the vestigial current-living-key loop.
- `test`: slash-after-rotation eviction regression.
