### PR TITLE
contracts: pay the finality-violation reporter unconditionally

### DIFF
--- a/contracts/SlashIndicator.sol
+++ b/contracts/SlashIndicator.sol
@@ -252,19 +252,17 @@ contract SlashIndicator is ISlashIndicator, System, IParamSubscriber, IApplicati
             "verify signature failed"
         );
 
-        // reward sender and felony validator if validator found
-        (address[] memory vals, bytes[] memory voteAddrs) =
-            IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).getLivingValidators();
-        for (uint256 i; i < voteAddrs.length; ++i) {
-            if (BytesLib.equal(voteAddrs[i], _evidence.voteAddr)) {
-                uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * felonySlashRewardRatio) / 100;
-                ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
-                IBSCValidatorSet(VALIDATOR_CONTRACT_ADDR).felony(vals[i]);
-                break;
-            }
-        }
-
+        // Slash + jail + evict the offender (StakeHub resolves the operator from the vote
+        // address and evicts it). If it reverts (e.g. already slashed / expired), the whole
+        // submission reverts and no reward is paid.
         IStakeHub(STAKE_HUB_ADDR).maliciousVoteSlash(_evidence.voteAddr);
+
+        // Reward the reporter unconditionally, mirroring submitDoubleSignEvidence. The prior
+        // implementation only paid when the vote address matched a CURRENT living validator's
+        // key, so a validator that rotated its vote key between the offence and the report was
+        // still fully slashed while the reporter received nothing.
+        uint256 amount = (address(SYSTEM_REWARD_ADDR).balance * felonySlashRewardRatio) / 100;
+        ISystemReward(SYSTEM_REWARD_ADDR).claimRewards(msg.sender, amount);
     }
 
     function submitDoubleSignEvidence(bytes memory header1, bytes memory header2) public onlyInit {


### PR DESCRIPTION
### Description

Pay the reporter of a finality-violation (malicious-vote) evidence submission unconditionally after the slash succeeds, instead of only when the evidence vote address still matches a current living validator's vote key.

### Rationale

`submitFinalityViolationEvidence` admits evidence for a vote key in the current OR previous set (`isMonitoredForMaliciousVote`) and punishes via `voteToOperator`, both of which survive a vote-key rotation. But the reporter reward was paid only inside a loop that matched the evidence vote address against a CURRENT validator's live key. A validator that rotates its vote key between the offence and the report is therefore fully slashed, jailed and evicted while the reporter matches nothing and receives zero — the reporter incentive fails for precisely the evidence it exists to reward. The sibling `submitDoubleSignEvidence` already pays unconditionally after the slash; this aligns the two paths.

### Example

A validator votes maliciously under vote key `V_old`, rotates to `V_new`, and an ordinary set sync moves `V_old` into the previous set. A reporter submits `V_old` evidence: the validator is slashed and evicted as before, and the reporter now receives the configured reward instead of nothing.

### Changes

- `SlashIndicator`: in `submitFinalityViolationEvidence`, call `maliciousVoteSlash` first (which resolves the operator from the vote address, evicts it, and reverts the whole submission on already-slashed/expired), then pay the reporter unconditionally. Remove the vestigial current-living-key loop.
